### PR TITLE
Test: JS-only change (preview workflow)

### DIFF
--- a/frontend/src/theme/colors.ts
+++ b/frontend/src/theme/colors.ts
@@ -55,3 +55,4 @@ export const getCaregiverColor = (caregiverId: string) => {
   const index = Math.abs(hash) % colors.caregiverColors.length;
   return colors.caregiverColors[index];
 };
+// test trigger


### PR DESCRIPTION
## Summary
- Trivial comment addition to colors.ts to test the updated PR preview workflow
- Should trigger the preview workflow and produce a working QR code (JS-only change)

## Test plan
- [ ] Preview workflow runs successfully
- [ ] QR code is posted via `expo-github-action/preview`
- [ ] No native change warning is posted