### PR TITLE
Update design doc to match actual implementation

### DIFF
--- a/docs/baby_baton_design.md
+++ b/docs/baby_baton_design.md
@@ -18,14 +18,16 @@ Baby Baton supports multiple families, where each family has one baby and multip
 - Caregiver management (all caregivers have equal permissions)
 - Care session management (start, add activities, complete)
 - Voice input with button confirmation
+- Manual activity entry as fallback when voice fails
+- Edit and delete activities in current session
 - Track: Feeds, Diaper changes, Sleep
 - Display last 3-4 completed care sessions + current in-progress session
 - Smart rule-based feed predictions
 - Local push notifications (15 min before predicted feed)
-- Delete activities
 - Leave family functionality
-- Family settings (view password, caregiver list, edit baby name)
+- Family settings (view password, caregiver list, baby name)
 - Responsive UI for all phone sizes
+- Cross-platform: iOS, Android, Web
 
 **Out of Scope (Post-MVP):**
 
@@ -43,55 +45,61 @@ Baby Baton supports multiple families, where each family has one baby and multip
 ### 1.3 Architecture Diagram
 
 ```
-┌─────────────────┐         ┌─────────────────┐
-│   iOS Device    │         │ Android Device  │
-│  (React Native) │         │ (React Native)  │
-│                 │         │                 │
-│  • Voice Input  │         │  • Voice Input  │
-│  • Local Notif  │         │  • Local Notif  │
-│  • Predictions  │         │  • Predictions  │
-│  • Family Auth  │         │  • Family Auth  │
-└────────┬────────┘         └────────┬────────┘
-         │                           │
-         │    GraphQL over HTTPS     │
-         │    Poll every 5 min       │
-         └──────────┬────────────────┘
-                    │
-         ┌──────────▼──────────┐
-         │   API Gateway       │
-         │   (Go - Port 8080)  │
-         └──────────┬──────────┘
-                    │
-         ┌──────────▼──────────┐
-         │   Business Logic    │
-         │   - Family Auth     │
-         │   - Session Mgmt    │
-         │   - Voice Parsing   │
-         │   - Predictions     │
-         └──────────┬──────────┘
-                    │
-         ┌──────────▼──────────┐
-         │   Claude API        │
-         │   (Voice Parsing)   │
-         └─────────────────────┘
+┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐
+│   iOS Device    │  │ Android Device  │  │   Web Browser   │
+│  (React Native) │  │ (React Native)  │  │  (Expo Web)     │
+│                 │  │                 │  │                 │
+│  • Voice Input  │  │  • Voice Input  │  │  • Voice Input  │
+│  • Manual Entry │  │  • Manual Entry │  │  • Manual Entry │
+│  • Predictions  │  │  • Predictions  │  │  • Predictions  │
+│  • Family Auth  │  │  • Family Auth  │  │  • Family Auth  │
+└────────┬────────┘  └────────┬────────┘  └────────┬────────┘
+         │                    │                     │
+         │    GraphQL over HTTPS                    │
+         │    Polls: 10s (current), 30s (recent)    │
+         └──────────┬─────────────┬─────────────────┘
+                    │             │
+         ┌──────────▼──────────┐  │
+         │   Go GraphQL Server │  │
+         │   (gqlgen - :8080)  │  │
+         │   Deployed: Railway │  │
+         └──────────┬──────────┘  │
+                    │             │
+         ┌──────────▼──────────┐  │
+         │   Business Logic    │  │
+         │   - Family Auth     │  │
+         │   - Session Mgmt    │  │
+         │   - Voice Parsing   │  │
+         │   - Predictions     │  │
+         └──┬──────────────┬───┘  │
+            │              │      │
+┌───────────▼───┐  ┌───────▼──────▼───┐
+│  OpenAI API   │  │   Claude API     │
+│  (Whisper     │  │   (Voice Text    │
+│  Transcribe)  │  │    Parsing)      │
+└───────────────┘  └──────────────────┘
                     │
          ┌──────────▼──────────┐
          │   PostgreSQL        │
-         │   (Docker)          │
+         │   (Docker local /   │
+         │    Railway prod)    │
          └─────────────────────┘
 ```
 
 ### 1.4 Technology Stack
 
-- **Backend:** Go 1.21+
+- **Backend:** Go 1.25+
 - **API:** GraphQL (gqlgen)
 - **Database:** PostgreSQL 15+
-- **Mobile:** React Native + TypeScript
-- **GraphQL Client:** Apollo Client
-- **Voice:** Device speech-to-text → Claude API for parsing
-- **Notifications:** Local notifications (react-native-push-notification)
+- **Frontend:** React Native (Expo SDK 54) + TypeScript
+- **GraphQL Client:** Apollo Client v4
+- **Voice:** Device audio recording → OpenAI Whisper API (transcription) → Claude API (parsing into structured activities)
+- **Manual Entry:** ManualEntryModal as fallback when voice input fails
 - **Password Hashing:** bcrypt
-- **Containerization:** Docker + Docker Compose
+- **Containerization:** Docker + Docker Compose (local PostgreSQL)
+- **Deployment:** Railway (backend + frontend web), EAS (native iOS/Android builds)
+- **CI/CD:** GitHub Actions
+- **Navigation:** React Navigation v7
 - **Repository:** GitHub (monorepo)
 
 ---
@@ -116,6 +124,8 @@ CREATE TABLE families (
 -- Case-insensitive lookup for family names
 CREATE UNIQUE INDEX idx_families_name_lower ON families(LOWER(name));
 ```
+
+**Note:** A `password` column (VARCHAR(100)) was added in migration 002 to store the plain-text password for display in settings. The `password_hash` stores the bcrypt hash for verification.
 
 #### `caregivers`
 
@@ -142,7 +152,7 @@ CREATE INDEX idx_caregivers_family_id ON caregivers(family_id);
 ```sql
 CREATE TABLE care_sessions (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    caregiver_id UUID NOT NULL REFERENCES caregivers(id),
+    caregiver_id UUID NOT NULL REFERENCES caregivers(id) ON DELETE CASCADE,
     family_id UUID NOT NULL REFERENCES families(id),
     status VARCHAR(20) NOT NULL CHECK (status IN ('in_progress', 'completed')),
     started_at TIMESTAMP NOT NULL DEFAULT NOW(),
@@ -158,6 +168,8 @@ CREATE INDEX idx_care_sessions_family ON care_sessions(family_id);
 CREATE INDEX idx_care_sessions_started_at ON care_sessions(started_at DESC);
 CREATE INDEX idx_care_sessions_family_status ON care_sessions(family_id, status);
 ```
+
+**Note:** `caregiver_id` has `ON DELETE CASCADE` (migration 003) — when a caregiver leaves, their sessions and all cascading activities/details are deleted.
 
 #### `activities`
 
@@ -232,11 +244,20 @@ CREATE INDEX idx_sleep_details_start_time ON sleep_details(start_time DESC);
 - **Family Isolation:** All data is scoped to family_id for data isolation
 - **Cascading Deletes:**
   - When family is deleted: All caregivers, sessions, and activities are removed
-  - When caregiver leaves (deleted): Their sessions remain but are orphaned (acceptable for MVP)
+  - When caregiver leaves (deleted): Their sessions and cascading activities/details are deleted (ON DELETE CASCADE, migration 003)
   - When care_session is deleted: All activities and their details are removed
 - **Device Uniqueness:** One device can only be in one family at a time
 - **Family Name:** Case-insensitive unique constraint for easy joining
 - **Timestamps:** All tables have created_at/updated_at for audit trail
+
+### 2.3 Migrations
+
+```
+migrations/
+├── 001_init_schema.sql                    # Core tables, indexes, triggers
+├── 002_add_password_to_families.sql       # Plain-text password column for settings display
+└── 003_cascade_delete_caregiver_sessions.sql  # ON DELETE CASCADE for caregiver sessions
+```
 
 ---
 
@@ -244,7 +265,7 @@ CREATE INDEX idx_sleep_details_start_time ON sleep_details(start_time DESC);
 
 ```graphql
 scalar DateTime
-scalar UUID
+scalar Upload
 
 # Enums
 enum CareSessionStatus {
@@ -271,16 +292,17 @@ enum PredictionConfidence {
 
 # Types
 type Family {
-  id: UUID!
+  id: ID!
   name: String!
   babyName: String!
+  password: String!
   caregivers: [Caregiver!]!
   createdAt: DateTime!
 }
 
 type Caregiver {
-  id: UUID!
-  familyId: UUID!
+  id: ID!
+  familyId: ID!
   name: String!
   deviceId: String!
   deviceName: String
@@ -288,9 +310,9 @@ type Caregiver {
 }
 
 type CareSession {
-  id: UUID!
+  id: ID!
   caregiver: Caregiver!
-  familyId: UUID!
+  familyId: ID!
   status: CareSessionStatus!
   startedAt: DateTime!
   completedAt: DateTime
@@ -329,25 +351,25 @@ type SleepDetails {
   startTime: DateTime!
   endTime: DateTime
   durationMinutes: Int
-  isActive: Boolean!
+  isActive: Boolean
 }
 
 type FeedActivity {
-  id: UUID!
+  id: ID!
   activityType: ActivityType!
   createdAt: DateTime!
   feedDetails: FeedDetails
 }
 
 type DiaperActivity {
-  id: UUID!
+  id: ID!
   activityType: ActivityType!
   createdAt: DateTime!
   diaperDetails: DiaperDetails
 }
 
 type SleepActivity {
-  id: UUID!
+  id: ID!
   activityType: ActivityType!
   createdAt: DateTime!
   sleepDetails: SleepDetails
@@ -360,9 +382,17 @@ type NextFeedPrediction {
   minutesUntilFeed: Int!
 }
 
+# Separate output type for parsed voice results (no id/createdAt)
+type ParsedActivity {
+  activityType: ActivityType!
+  feedDetails: FeedDetails
+  diaperDetails: DiaperDetails
+  sleepDetails: SleepDetails
+}
+
 type ParsedVoiceResult {
   success: Boolean!
-  parsedActivities: [ActivityInput!]!
+  parsedActivities: [ParsedActivity!]!
   errors: [String!]
   rawText: String!
 }
@@ -407,10 +437,10 @@ type Query {
   getMyFamily: Family
   getMyCaregiver: Caregiver
 
-  # Care Sessions
-  getRecentCareSessions(limit: Int = 4): [CareSession!]!
+  # Care Sessions (automatically scoped to authenticated caregiver's family)
+  getRecentCareSessions(limit: Int): [CareSession!]!
   getCurrentSession: CareSession
-  getCareSession(id: UUID!): CareSession
+  getCareSession(id: ID!): CareSession
 
   # Predictions
   predictNextFeed: NextFeedPrediction!
@@ -443,17 +473,17 @@ type Mutation {
   # Care Session Management
   startCareSession: CareSession!
 
-  parseVoiceInput(text: String!): ParsedVoiceResult!
+  parseVoiceInput(audioFile: Upload!): ParsedVoiceResult!
 
   addActivities(activities: [ActivityInput!]!): CareSession!
 
-  addActivitiesFromVoice(text: String!): CareSession!
-
-  endActivity(activityId: UUID!, endTime: DateTime): Activity!
+  endActivity(activityId: ID!, endTime: DateTime): Activity!
 
   completeCareSession(notes: String): CareSession!
 
-  deleteActivity(activityId: UUID!): Boolean!
+  deleteActivity(activityId: ID!): Boolean!
+
+  updateActivity(activityId: ID!, input: ActivityInput!): Activity!
 }
 ```
 
@@ -468,15 +498,23 @@ type Mutation {
 **Authentication Flow:**
 
 - Device-based authentication (deviceId stored after family join/create)
+- Headers sent on every request: `X-Family-ID`, `X-Caregiver-ID`, `X-Timezone`
 - Password hashed with bcrypt
 - Family name is case-insensitive
 - Password shown in plain text in settings (for easy sharing)
+
+**JoinFamily — Three-Case Handling:**
+
+- **Same device, same family:** Re-authenticates (returns existing caregiver)
+- **Same device, different family:** Blocks with error ("Device already belongs to a family")
+- **New device:** Creates new caregiver in the family
 
 **Single Active Session:**
 
 - Only ONE in-progress session allowed per family at a time
 - Enforced in application logic
 - When new session starts: Auto-completes previous session (if exists) with current timestamp
+- **Handoff logic:** When a different caregiver adds activities via `addActivities`, the existing session auto-completes (active sleeps auto-ended) and a new session is created for the new caregiver
 
 **Activity Recording Rules:**
 
@@ -485,31 +523,36 @@ type Mutation {
   - End time: User-provided OR auto-calculated as `start_time + 45 minutes`
   - Example: "Fed 60ml at 2pm" → 2:00pm - 2:45pm (default)
   - Example: "Fed 60ml from 2pm to 2:20pm" → 2:00pm - 2:20pm (user-provided)
-  - No manual editing after creation
+  - Can be edited via `updateActivity` mutation in current session
 - **Diaper Activities:**
   - Required: timestamp, had_poop, had_pee
   - Instant activity, no duration
+  - Can be edited via `updateActivity` mutation in current session
 - **Sleep Activities:**
   - Required: start_time
   - End time: Optional (null = ongoing/active)
   - Only ONE incomplete sleep allowed per session
   - Can be ended via `endActivity` mutation (Mark as Awake button)
   - Auto-ended when session completes
+  - Can be edited via `updateActivity` mutation in current session
 
 **Session Completion:**
 
 - Manual: User clicks "Complete Care Session" → Auto-ends any active sleep
 - Automatic: New session starts → Previous session auto-completes → Active sleep auto-ended
+- Automatic handoff: Different caregiver adds activities → Previous session auto-completes
 
 **Leave Family:**
 
 - Deletes caregiver record
 - Device becomes available to join another family
-- Sessions created by that caregiver remain (orphaned but visible)
+- Sessions and activities created by that caregiver are cascade-deleted (ON DELETE CASCADE)
 
 ---
 
 ## 4. Smart Feed Prediction Algorithm
+
+> **Status: NOT YET IMPLEMENTED.** The `predictNextFeed` query currently returns mock data (2 hours from now, HIGH confidence, static reasoning string). The algorithm below is the planned design.
 
 ### 4.1 Rule-Based Prediction Engine
 
@@ -630,6 +673,8 @@ func calculateConfidence(factors PredictionFactors) PredictionConfidence {
 
 ## 5. Local Notification System
 
+> **Status: NOT YET IMPLEMENTED.** No notification service or scheduling code exists in the codebase. The design below is planned but not built.
+
 ### 5.1 Notification Flow
 
 ```
@@ -676,9 +721,9 @@ Event Trigger: Activity added OR care session completed OR app opened (poll)
 
 **Solution:**
 
-- Device B polls every 5 minutes
+- Device B polls periodically
 - On poll, if new data found, recalculate and reschedule
-- Max staleness: 5 minutes (acceptable for MVP)
+- Acceptable staleness for MVP
 
 ---
 
@@ -688,434 +733,144 @@ Event Trigger: Activity added OR care session completed OR app opened (poll)
 
 ```
 backend/
-├── cmd/
-│   └── server/
-│       └── main.go                 # Entry point
-├── internal/
-│   ├── api/
-│   │   ├── resolver.go            # GraphQL root resolver
-│   │   ├── schema.resolvers.go    # Generated resolvers
-│   │   └── schema.graphql         # GraphQL schema definition
-│   ├── db/
-│   │   ├── postgres.go            # DB connection & queries
-│   │   ├── migrations/            # SQL migration files
-│   │   │   ├── 001_init.sql
-│   │   │   └── 002_add_families.sql
-│   │   └── repository.go          # Data access layer
-│   ├── domain/
-│   │   ├── models.go              # Domain models
-│   │   ├── family.go
-│   │   ├── caregiver.go
-│   │   ├── care_session.go
-│   │   └── activity.go
-│   ├── service/
-│   │   ├── family_service.go      # Family & auth logic
-│   │   ├── care_session_service.go # Business logic
-│   │   ├── voice_service.go       # Voice parsing with Claude
-│   │   └── prediction_service.go  # Feed prediction engine
-│   ├── auth/
-│   │   └── device_auth.go         # Device-based authentication
-│   └── ai/
-│       └── claude_client.go       # Claude API client
-├── pkg/
-│   └── utils/
-│       ├── time.go                # Time utilities
-│       ├── errors.go              # Error handling
-│       └── password.go            # bcrypt helpers
-├── go.mod
-├── go.sum
-├── .env.example
-└── Dockerfile
+├── server.go                       # Entry point (port 8080)
+├── Dockerfile                      # Multi-stage build for Railway
+├── .env                            # API keys (never commit)
+├── graph/
+│   ├── resolver.go                 # DI: Store interface injection
+│   ├── schema.resolvers.go         # All resolver implementations
+│   ├── helpers.go                  # loadCareSessionWithActivities, summary builder
+│   ├── mock_data.go                # Mock prediction data (TODO: replace)
+│   └── generated.go                # AUTO-GENERATED by gqlgen — do not edit
+└── internal/
+    ├── ai/
+    │   ├── whisper_client.go       # OpenAI Whisper transcription
+    │   ├── claude_client.go        # Claude API for voice text parsing
+    │   └── parser.go              # JSON → ParsedActivity/ActivityInput converters
+    ├── domain/
+    │   └── models.go              # All domain models + enums
+    ├── mapper/
+    │   └── to_graphql.go          # Domain → GraphQL type converters
+    ├── middleware/
+    │   └── auth.go                # Header-based auth (X-Family-ID, X-Caregiver-ID, X-Timezone)
+    └── store/
+        ├── store.go               # Store interface definition
+        └── postgres/
+            ├── postgres.go        # PostgreSQL implementation
+            └── postgres_test.go   # Integration tests
 ```
 
-### 6.2 Family Service - Authentication
+**Key architectural note:** There is no separate service layer. All business logic (family auth, session management, activity handling) lives directly in the GraphQL resolvers (`schema.resolvers.go`). The `Store` interface abstracts all database operations and is injected into the resolver via dependency injection.
+
+### 6.2 Resolver Architecture
+
+All business logic is implemented directly in GraphQL resolvers. The resolver receives a `Store` interface at initialization for database operations.
 
 ```go
-// internal/service/family_service.go
-type FamilyService struct {
-    repo   *db.Repository
-    logger *log.Logger
+// graph/resolver.go
+type Resolver struct {
+    Store store.Store
 }
 
-func (s *FamilyService) CreateFamily(
-    ctx context.Context,
-    familyName string,
-    password string,
-    babyName string,
-    caregiverName string,
-    deviceID string,
-    deviceName *string,
-) (*domain.Family, *domain.Caregiver, error) {
-    // Check family name availability (case-insensitive)
-    exists, err := s.repo.FamilyNameExists(ctx, familyName)
-    if err != nil {
-        return nil, nil, fmt.Errorf("failed to check family name: %w", err)
-    }
-    if exists {
-        return nil, nil, errors.New("Family name already taken")
-    }
-
-    // Validate password length
-    if len(password) < 6 {
-        return nil, nil, errors.New("Password must be at least 6 characters")
-    }
-
-    // Hash password
-    passwordHash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
-    if err != nil {
-        return nil, nil, fmt.Errorf("failed to hash password: %w", err)
-    }
-
-    // Create family
-    family := &domain.Family{
-        ID:           uuid.New(),
-        Name:         familyName,
-        PasswordHash: string(passwordHash),
-        BabyName:     babyName,
-    }
-
-    if err := s.repo.CreateFamily(ctx, family); err != nil {
-        return nil, nil, fmt.Errorf("failed to create family: %w", err)
-    }
-
-    // Create caregiver
-    caregiver := &domain.Caregiver{
-        ID:         uuid.New(),
-        FamilyID:   family.ID,
-        Name:       caregiverName,
-        DeviceID:   deviceID,
-        DeviceName: deviceName,
-    }
-
-    if err := s.repo.CreateCaregiver(ctx, caregiver); err != nil {
-        return nil, nil, fmt.Errorf("failed to create caregiver: %w", err)
-    }
-
-    return family, caregiver, nil
-}
-
-func (s *FamilyService) JoinFamily(
-    ctx context.Context,
-    familyName string,
-    password string,
-    caregiverName string,
-    deviceID string,
-    deviceName *string,
-) (*domain.Family, *domain.Caregiver, error) {
-    // Find family (case-insensitive)
-    family, err := s.repo.GetFamilyByName(ctx, familyName)
-    if err != nil {
-        if err == sql.ErrNoRows {
-            return nil, nil, errors.New("Family not found")
-        }
-        return nil, nil, fmt.Errorf("failed to find family: %w", err)
-    }
-
-    // Verify password
-    if err := bcrypt.CompareHashAndPassword([]byte(family.PasswordHash), []byte(password)); err != nil {
-        return nil, nil, errors.New("Incorrect password")
-    }
-
-    // Check if device already in a family
-    existingCaregiver, err := s.repo.GetCaregiverByDeviceID(ctx, deviceID)
-    if err != nil && err != sql.ErrNoRows {
-        return nil, nil, fmt.Errorf("failed to check device: %w", err)
-    }
-    if existingCaregiver != nil {
-        return nil, nil, errors.New("Device already belongs to a family. Leave current family first.")
-    }
-
-    // Create caregiver
-    caregiver := &domain.Caregiver{
-        ID:         uuid.New(),
-        FamilyID:   family.ID,
-        Name:       caregiverName,
-        DeviceID:   deviceID,
-        DeviceName: deviceName,
-    }
-
-    if err := s.repo.CreateCaregiver(ctx, caregiver); err != nil {
-        return nil, nil, fmt.Errorf("failed to create caregiver: %w", err)
-    }
-
-    return family, caregiver, nil
-}
-
-func (s *FamilyService) LeaveFamily(
-    ctx context.Context,
-    caregiverID string,
-) error {
-    // Simply delete the caregiver
-    // Sessions remain but are orphaned (acceptable for MVP)
-    if err := s.repo.DeleteCaregiver(ctx, caregiverID); err != nil {
-        return fmt.Errorf("failed to leave family: %w", err)
-    }
-
-    return nil
-}
-
-func (s *FamilyService) UpdateBabyName(
-    ctx context.Context,
-    familyID string,
-    babyName string,
-) (*domain.Family, error) {
-    family, err := s.repo.GetFamilyByID(ctx, familyID)
-    if err != nil {
-        return nil, fmt.Errorf("failed to get family: %w", err)
-    }
-
-    family.BabyName = babyName
-
-    if err := s.repo.UpdateFamily(ctx, family); err != nil {
-        return nil, fmt.Errorf("failed to update baby name: %w", err)
-    }
-
-    return family, nil
+func NewResolver(store store.Store) *Resolver {
+    return &Resolver{Store: store}
 }
 ```
 
-### 6.3 Care Session Service - Family Scoping
+Key resolver behaviors:
+
+- **CreateFamily:** Validates password (min 6 chars), checks family name uniqueness (case-insensitive), hashes password with bcrypt, creates family + caregiver atomically
+- **JoinFamily:** Three-case handling: (1) re-auth same device/family, (2) block different family, (3) create new caregiver
+- **AddActivities:** Core workflow resolver with handoff logic — if a different caregiver adds activities, auto-completes the old session + ends active sleeps, creates a new session for the new caregiver
+- **CompleteCareSession:** Completes in-progress session, auto-ends all active sleep activities
+- **UpdateActivity:** Updates any activity type's details, recalculates duration for feeds/sleeps
+
+### 6.3 Voice Parsing Pipeline
+
+Voice input follows a three-stage pipeline:
+
+1. **Audio Recording** (frontend): Device records audio via microphone
+2. **Transcription** (backend → OpenAI Whisper): Raw audio uploaded to backend, sent to OpenAI Whisper v1 API, returns transcribed text. Retries up to 3 times on failure.
+3. **Parsing** (backend → Claude API): Transcribed text sent to Claude Sonnet 4.6 with a structured prompt. Uses exponential backoff retry for rate limits (429, 529 status codes). Returns JSON array of parsed activities.
 
 ```go
-// internal/service/care_session_service.go
-type CareSessionService struct {
-    repo   *db.Repository
-    logger *log.Logger
-}
-
-func (s *CareSessionService) StartCareSession(
-    ctx context.Context,
-    caregiverID string,
-    familyID string,
-) (*domain.CareSession, error) {
-    // Check if there's already an in-progress session FOR THIS FAMILY
-    existingSession, err := s.repo.GetInProgressSessionForFamily(ctx, familyID)
-    if err != nil && err != sql.ErrNoRows {
-        return nil, fmt.Errorf("failed to check existing session: %w", err)
-    }
-
-    // Auto-complete previous session if exists
-    if existingSession != nil {
-        now := time.Now()
-
-        // End any active sleep activities
-        if err := s.endActiveSleepActivities(ctx, existingSession.ID, now); err != nil {
-            return nil, fmt.Errorf("failed to end active sleep: %w", err)
-        }
-
-        // Complete the session
-        existingSession.Status = domain.StatusCompleted
-        existingSession.CompletedAt = now
-        if err := s.repo.UpdateCareSession(ctx, existingSession); err != nil {
-            return nil, fmt.Errorf("failed to complete existing session: %w", err)
-        }
-
-        s.logger.Printf("Auto-completed previous session %s", existingSession.ID)
-    }
-
-    // Create new session
-    session := &domain.CareSession{
-        ID:          uuid.New(),
-        CaregiverID: caregiverID,
-        FamilyID:    familyID,
-        Status:      domain.StatusInProgress,
-        StartedAt:   time.Now(),
-    }
-
-    if err := s.repo.CreateCareSession(ctx, session); err != nil {
-        return nil, fmt.Errorf("failed to create session: %w", err)
-    }
-
-    return session, nil
-}
-
-// All other methods remain similar but always scope by familyID
-func (s *CareSessionService) GetRecentCareSessions(
-    ctx context.Context,
-    familyID string,
-    limit int,
-) ([]*domain.CareSession, error) {
-    return s.repo.GetRecentCareSessionsForFamily(ctx, familyID, limit)
-}
-
-func (s *CareSessionService) GetCurrentSession(
-    ctx context.Context,
-    familyID string,
-) (*domain.CareSession, error) {
-    return s.repo.GetInProgressSessionForFamily(ctx, familyID)
-}
-
-func (s *CareSessionService) CompleteCareSession(
-    ctx context.Context,
-    notes string,
-) (*domain.CareSession, error) {
-    session, err := s.repo.GetInProgressSession(ctx)
-    if err != nil {
-        if err == sql.ErrNoRows {
-            return nil, errors.New("No active care session to complete")
-        }
-        return nil, fmt.Errorf("failed to get session: %w", err)
-    }
-
-    now := time.Now()
-
-    // End any active sleep activities
-    if err := s.endActiveSleepActivities(ctx, session.ID, now); err != nil {
-        return nil, fmt.Errorf("failed to end active sleep: %w", err)
-    }
-
-    // Complete session
-    session.Status = domain.StatusCompleted
-    session.CompletedAt = now
-    session.Notes = notes
-
-    if err := s.repo.UpdateCareSession(ctx, session); err != nil {
-        return nil, fmt.Errorf("failed to complete session: %w", err)
-    }
-
-    return session, nil
-}
-
-func (s *CareSessionService) endActiveSleepActivities(
-    ctx context.Context,
-    sessionID string,
-    endTime time.Time,
-) error {
-    // Get all sleep activities for session without end_time
-    sleepActivities, err := s.repo.GetActiveSleepActivities(ctx, sessionID)
-    if err != nil {
-        return err
-    }
-
-    for _, activity := range sleepActivities {
-        activity.SleepDetails.EndTime = endTime
-        activity.SleepDetails.DurationMinutes = int(endTime.Sub(activity.SleepDetails.StartTime).Minutes())
-        if err := s.repo.UpdateSleepActivity(ctx, activity); err != nil {
-            return err
-        }
-    }
-
-    return nil
-}
+// Simplified flow in parseVoiceInput resolver:
+// 1. Receive audio file upload
+rawText, err := whisperClient.TranscribeAudio(audioFile)
+// 2. Parse text with Claude (timezone-aware)
+timezone := middleware.GetTimezone(ctx)
+parsedJSON, err := claudeClient.ParseVoiceInput(rawText, time.Now(), timezone)
+// 3. Convert to GraphQL types
+activities, errors := ai.ConvertToParsedActivities(parsedJSON)
+// 4. Return for user confirmation
+return ParsedVoiceResult{Success: true, ParsedActivities: activities, RawText: rawText}
 ```
-
-### 6.4 Voice Parsing with Claude
 
 #### Prompt Template
 
-```go
-const voiceParsingPrompt = `You are parsing baby care voice input into structured activities.
+The Claude prompt is timezone-aware (uses `X-Timezone` header) and defines extraction rules for each activity type:
 
-Current time: {{.CurrentTime}}
-Current timezone: {{.Timezone}}
+- **FEED:** Requires start_time, amount_ml, feed_type. Default feed type is "formula" if not specified.
+- **SLEEP:** Requires start_time. End time null means ongoing/active sleep.
+- **DIAPER:** Requires changed_at, had_poop, had_pee.
 
-Voice input: "{{.VoiceText}}"
-
-Rules:
-1. "now" or "right now" = current time
-2. Relative times like "at 2:30" are absolute within today
-3. Default feed type to "formula" if not specified
-4. "pooped" means had_poop=true for diaper change
-
-FEED ACTIVITIES:
-- MUST have: start_time, amount_ml, feed_type
-- If end_time provided: use it
-- If end_time NOT provided: set to null (will auto-calculate as start_time + 45 minutes)
-- Examples:
-  * "Fed 60ml at 2pm" → start: 2pm, end: null
-  * "Fed 60ml from 2pm to 2:20pm" → start: 2pm, end: 2:20pm
-
-SLEEP ACTIVITIES:
-- MUST have: start_time
-- If end_time provided: use it (completed nap)
-- If end_time NOT provided: set to null (ongoing/active sleep)
-- Examples:
-  * "Napped from 2pm to 3pm" → start: 2pm, end: 3pm
-  * "Started napping at 2pm" → start: 2pm, end: null
-  * "She's sleeping now" → start: current_time, end: null
-
-DIAPER ACTIVITIES:
-- MUST have: changed_at timestamp
-- Extract had_poop and had_pee from context
-
-Extract all activities mentioned. Return JSON array:
-
-[
-  {
-    "activity_type": "FEED|DIAPER|SLEEP",
-    "feed_details": {
-      "start_time": "2024-01-15T14:30:00Z",
-      "end_time": null,
-      "amount_ml": 60,
-      "feed_type": "FORMULA"
-    },
-    "diaper_details": {
-      "changed_at": "2024-01-15T14:55:00Z",
-      "had_poop": true,
-      "had_pee": true
-    },
-    "sleep_details": {
-      "start_time": "2024-01-15T15:00:00Z",
-      "end_time": null
-    }
-  }
-]
-
-If you cannot parse the input, return: {"error": "reason"}`
-```
+Returns a JSON array of activities. If parsing fails, returns `{"error": "reason"}`.
 
 ---
 
-## 7. Mobile App Architecture
+## 7. Frontend Architecture
 
 ### 7.1 Project Structure
 
 ```
-mobile/
+frontend/
+├── App.tsx                         # Root: Apollo → Auth → Navigation
+├── app.json                        # Expo config (runtimeVersion, etc.)
+├── eas.json                        # EAS build profiles (dev/preview/production)
+├── codegen.ts                      # GraphQL codegen config
+├── Dockerfile                      # Expo web export served by `serve`
 ├── src/
 │   ├── components/
-│   │   ├── CareSessionCard.tsx    # Completed care session display
-│   │   ├── ActivityItem.tsx       # Single activity display
-│   │   ├── VoiceButton.tsx        # Voice recording UI
-│   │   ├── ConfirmationModal.tsx  # Voice parse confirmation
-│   │   ├── PredictionCard.tsx     # Next feed prediction
-│   │   └── FamilyAvatar.tsx       # Header avatar with baby name
+│   │   ├── ActivityConfirmationModal.tsx  # Voice parse review & confirm
+│   │   ├── ActivityItem.tsx              # Single activity (swipe-to-delete, tap-to-edit)
+│   │   ├── CaregiverAvatar.tsx           # Initials badge (hash-colored)
+│   │   ├── CurrentSessionCard.tsx        # Dashboard: active session card
+│   │   ├── CustomHeader.tsx              # Navigation header with avatar
+│   │   ├── EditActivityModal.tsx         # Edit existing activity details
+│   │   ├── ManualEntryModal.tsx          # Manual activity entry fallback
+│   │   ├── PredictionCard.tsx            # Dashboard: next feed prediction
+│   │   ├── RecentSessionCard.tsx         # Dashboard: completed session card
+│   │   └── VoiceInputModal.tsx           # Voice recording & processing
 │   ├── screens/
-│   │   ├── WelcomeScreen.tsx           # Family create/join
-│   │   ├── HomeScreen.tsx              # Main dashboard
-│   │   ├── SettingsScreen.tsx          # Family settings
-│   │   ├── PredictionDetailScreen.tsx  # Full prediction reasoning
-│   │   ├── CurrentSessionDetailScreen.tsx # Current session with delete
-│   │   └── SessionDetailScreen.tsx     # Completed session (read-only)
-│   ├── graphql/
-│   │   ├── queries.ts             # GraphQL queries
-│   │   ├── mutations.ts           # GraphQL mutations
-│   │   ├── client.ts              # Apollo client setup
-│   │   └── mocks.ts               # Mock data for testing
-│   ├── services/
-│   │   ├── voiceService.ts        # Speech-to-text
-│   │   ├── notificationService.ts # Local notifications
-│   │   ├── predictionService.ts   # Client-side prediction
-│   │   ├── deviceService.ts       # Device ID extraction
-│   │   └── authService.ts         # Family auth & device storage
-│   ├── hooks/
-│   │   ├── useCareSessions.ts     # Data fetching
-│   │   ├── useVoiceInput.ts       # Voice recording
-│   │   ├── usePolling.ts          # Polling logic
-│   │   ├── usePrediction.ts       # Prediction + notification
-│   │   └── useAuth.ts             # Authentication state
+│   │   ├── WelcomeScreen.tsx
+│   │   ├── CreateFamilyScreen.tsx
+│   │   ├── JoinFamilyScreen.tsx
+│   │   ├── DashboardScreen.tsx           # Main hub
+│   │   ├── CurrentSessionDetailScreen.tsx
+│   │   ├── SessionDetailScreen.tsx       # Completed session (read-only)
+│   │   ├── PredictionDetailScreen.tsx
+│   │   └── SettingsScreen.tsx
 │   ├── navigation/
-│   │   └── AppNavigator.tsx       # React Navigation
+│   │   └── AppNavigator.tsx              # React Navigation v7 stack
+│   ├── graphql/
+│   │   ├── client.ts                     # Apollo Client v4 + upload support
+│   │   ├── queries.ts
+│   │   └── mutations.ts
+│   ├── contexts/
+│   │   └── AuthContext.tsx               # Auth state provider
+│   ├── hooks/
+│   │   └── useAuth.ts                    # Auth context consumer
+│   ├── services/
+│   │   ├── authService.ts               # AsyncStorage auth persistence
+│   │   └── deviceService.ts             # UUID generation, device name detection
+│   ├── config.ts                         # API URL resolution
 │   ├── theme/
-│   │   ├── colors.ts              # Color palette
-│   │   ├── typography.ts          # Font styles
-│   │   └── spacing.ts             # Responsive spacing
-│   └── types/
-│       └── graphql.ts             # Generated TS types
-├── App.tsx
-├── app.json
-├── package.json
-└── tsconfig.json
+│   │   ├── colors.ts                     # Color palette + caregiver colors
+│   │   └── spacing.ts                    # Responsive spacing + typography scale
+│   ├── types/__generated__/              # AUTO-GENERATED by graphql-codegen — do not edit
+│   └── utils/
+│       └── time.ts                       # formatTime, formatDuration helpers
+└── __mocks__/                            # Jest mocks
 ```
 
 ### 7.2 Responsive Design System
@@ -1124,24 +879,36 @@ mobile/
 // theme/spacing.ts
 import { Dimensions } from "react-native";
 
-const { width, height } = Dimensions.get("window");
+const { width } = Dimensions.get("window");
 
 export const spacing = {
-  xs: width * 0.02, // 8px on 375w
-  sm: width * 0.04, // 16px
-  md: width * 0.06, // 24px
-  lg: width * 0.08, // 32px
-  xl: width * 0.12, // 48px
+  xs: width * 0.02, // ~8px on 375w
+  sm: width * 0.04, // ~16px
+  md: width * 0.06, // ~24px
+  lg: width * 0.08, // ~32px
+  xl: width * 0.12, // ~48px
 };
 
-export const button = {
-  minHeight: Math.max(60, height * 0.08), // 8% of screen, min 60px
-  fontSize: Math.max(16, width * 0.045), // Scale with screen
+export const layout = {
+  cardWidth: "90%",      // 90% of screen width
+  maxCardWidth: 450,     // Cap for tablets
+  minTouchTarget: 44,    // iOS HIG minimum
+  borderRadius: {
+    small: 8,
+    medium: 12,
+    large: 16,
+    round: 9999,
+  },
 };
 
-export const card = {
-  width: width * 0.9, // 90% of screen width
-  maxWidth: 500, // Cap for tablets
+export const typography = {
+  xs: 12,
+  sm: 14,
+  base: 16,
+  lg: 18,
+  xl: 20,
+  xxl: 24,
+  xxxl: 32,
 };
 ```
 
@@ -1178,6 +945,9 @@ export const colors = {
   diaper: "#FFB6A3",
   sleep: "#B19CD9",
 };
+
+// Caregiver colors: 5 fixed badge color pairs, deterministic by caregiver ID hash
+export const getCaregiverColor = (caregiverId: string) => { ... };
 ```
 
 ---
@@ -1233,6 +1003,7 @@ export const colors = {
 │  │ Mom                         ││
 │  └─────────────────────────────┘│
 │  Quick: [Mom] [Dad] [Grandma]   │
+│         [Grandpa] [Nanny]       │
 │                                 │
 │  ┌─────────────────────────────┐│
 │  │     Create Family           ││
@@ -1262,6 +1033,7 @@ export const colors = {
 │  │ Dad                         ││
 │  └─────────────────────────────┘│
 │  Quick: [Mom] [Dad] [Grandma]   │
+│         [Grandpa] [Nanny]       │
 │                                 │
 │  ┌─────────────────────────────┐│
 │  │      Join Family            ││
@@ -1272,29 +1044,26 @@ export const colors = {
 └─────────────────────────────────┘
 ```
 
-### 8.4 Home Screen (Dashboard) - Summary View
+### 8.4 Dashboard Screen
 
-**Header:**
-
-- Baby name + avatar (tappable → Settings)
-- App name: "Baby Baton"
+**Header:** `[Baby's Name]'s Baton` with caregiver avatar (tappable → Settings)
 
 ```
 ┌─────────────────────────────────┐
-│  🍼 Baby Baton    [👶 Emma] →   │
+│  Emma's Baton            [Mo] → │
 ├─────────────────────────────────┤
 │                                 │
 │  🔮 Next Feed Prediction     >  │
 │  ┌─────────────────────────────┐│
+│  │  ░░░░░ gradient card ░░░░░  ││
 │  │  Upcoming Feed              ││
-│  │  Scheduled for 5:15 PM      ││
-│  │  📊 High confidence          ││
+│  │  5:15 PM                    ││
 │  └─────────────────────────────┘│
 │                                 │
-│  📋 Current Care Session     >  │
+│  📋 Ongoing Care Session     >  │
 │  ┌─────────────────────────────┐│
-│  │  Started: 2:00 PM by Mom    ││
-│  │  Duration: 2h 45m            ││
+│  │  Started: 2:00 PM by [Mo]  ││
+│  │  Duration: 2h 45m           ││
 │  │                              ││
 │  │  🍼 Fed 70ml formula         ││
 │  │  💩 Changed diaper           ││
@@ -1305,16 +1074,19 @@ export const colors = {
 │                                 │
 │  📋 Recent Care Sessions        │
 │  ┌─────────────────────────────┐│
-│  │  11:30 AM - 1:45 PM by Dad >││
-│  │  Duration: 2h 15m            ││
+│  │  11:30 AM - 1:45 PM [Da] > ││
 │  │  2 feeds • 130ml • 1h sleep ││
 │  └─────────────────────────────┘│
 │                                 │
-│  ┌─────────────────────────────┐ │
-│  │   🎤  Add Activity          │ │
-│  └─────────────────────────────┘ │
+│  ┌──────────────┐ ┌────────────┐│
+│  │  🎤 Voice    │ │ ✏️ Manual  ││
+│  └──────────────┘ └────────────┘│
 └─────────────────────────────────┘
 ```
+
+**Bottom Bar:** Two sticky buttons:
+- **Voice** (left, blue `#5B9BD5`): Opens VoiceInputModal
+- **Manual** (right, darker blue `#2E6FA8`): Opens ManualEntryModal
 
 ### 8.5 Settings Screen
 
@@ -1326,12 +1098,7 @@ export const colors = {
 │  Family Information             │
 │  ┌─────────────────────────────┐│
 │  │ Family: Smith Family        ││
-│  │                             ││
-│  │ Baby Name                   ││
-│  │ ┌───────────────────────┐   ││
-│  │ │ Emma                  │   ││
-│  │ └───────────────────────┘   ││
-│  │ [Update Baby Name]          ││
+│  │ Baby: Emma                  ││
 │  └─────────────────────────────┘│
 │                                 │
 │  ─────────────────────────────  │
@@ -1362,16 +1129,21 @@ export const colors = {
 └─────────────────────────────────┘
 ```
 
+**Note:** Baby name is currently display-only. The `updateBabyName` mutation exists in the backend but is not wired up in the UI.
+
 ### 8.6 Prediction Detail Screen
 
 ```
 ┌─────────────────────────────────┐
-│  ← Prediction Details           │
+│  ← Next Feed                    │
 ├─────────────────────────────────┤
 │                                 │
-│  🔮 Upcoming Feed for Emma      │
-│  Scheduled for 5:15 PM          │
-│  📊 High confidence              │
+│       ┌───────────────┐         │
+│       │   5:15 PM     │         │
+│       └───────────────┘         │
+│                                 │
+│       📊 High confidence         │
+│       In about 2 hours          │
 │                                 │
 │  ─────────────────────────────  │
 │                                 │
@@ -1383,12 +1155,8 @@ export const colors = {
 │                                 │
 │  ─────────────────────────────  │
 │                                 │
-│  Prediction Factors:            │
-│  • Avg interval: 3.2 hours      │
-│  • Last amount: Above average   │
-│  • Currently sleeping: Yes      │
-│  • Time of day: Afternoon       │
-│  • Confidence: High             │
+│  ⚠ Feed approaching!           │
+│  (shown if < 30 min away)       │
 │                                 │
 └─────────────────────────────────┘
 ```
@@ -1400,7 +1168,7 @@ export const colors = {
 │  ← Current Care Session         │
 ├─────────────────────────────────┤
 │                                 │
-│  👤 Mom                         │
+│  [Mo] Mom                       │
 │  Started: 2:00 PM               │
 │  Duration: 2h 45m               │
 │                                 │
@@ -1409,30 +1177,27 @@ export const colors = {
 │  Activities (4):                │
 │                                 │
 │  ┌─────────────────────────────┐│
-│  │ 🍼 Fed 70ml formula         ││
+│  │ 🍼 Fed 70ml formula    ← ⌫ ││
 │  │    2:00 PM - 2:20 PM        ││
 │  │    Duration: 20 minutes     ││
-│  │    [Delete Activity]         ││
 │  └─────────────────────────────┘│
 │                                 │
 │  ┌─────────────────────────────┐│
-│  │ 💩 Changed diaper           ││
+│  │ 💩 Changed diaper      ← ⌫ ││
 │  │    2:25 PM                  ││
 │  │    Had poop ✓               ││
-│  │    [Delete Activity]         ││
 │  └─────────────────────────────┘│
 │                                 │
 │  ┌─────────────────────────────┐│
-│  │ 😴 Nap #1                   ││
+│  │ 😴 Nap #1              ← ⌫ ││
 │  │    10:30 AM - 11:30 AM      ││
 │  │    Duration: 1h             ││
-│  │    [Delete Activity]         ││
 │  └─────────────────────────────┘│
 │                                 │
 │  ┌─────────────────────────────┐│
-│  │ 😴 Nap #2 (Active)          ││
+│  │ 😴 Nap #2 (Active)    LIVE ││
 │  │    Started: 2:30 PM         ││
-│  │    Duration: 2h 15m (LIVE)  ││
+│  │    Duration: 2h 15m         ││
 │  │    [Mark as Awake]          ││
 │  └─────────────────────────────┘│
 │                                 │
@@ -1448,19 +1213,60 @@ export const colors = {
 └─────────────────────────────────┘
 ```
 
+**Interactions:**
+- **Swipe left** on any activity → reveals Delete action
+- **Tap** on any activity → opens EditActivityModal
+- **Mark as Awake** → calls `endActivity` mutation
+- Activities show `← ⌫` to indicate swipe-to-delete
+
 ### 8.8 Voice Input Flow
 
 ```
-Confirmation Modal:
+Step 1: VoiceInputModal
+┌─────────────────────────────────┐
+│                                 │
+│         ┌───────────┐           │
+│         │     🎤    │           │
+│         │  (80px)   │           │
+│         └───────────┘           │
+│    ═══ waveform animation ═══   │
+│                                 │
+│      Tap to start recording     │
+│                                 │
+│  Try saying:                    │
+│  "Fed 60ml formula at 2pm"     │
+│  "Changed diaper, had poop"    │
+│  "She's sleeping now"          │
+│                                 │
+└─────────────────────────────────┘
+
+Step 2: Processing
+┌─────────────────────────────────┐
+│                                 │
+│       ⟳ Processing audio...    │
+│                                 │
+└─────────────────────────────────┘
+
+Step 3: Error (fallback to manual)
+┌─────────────────────────────────┐
+│                                 │
+│     ⚠ Couldn't process audio   │
+│                                 │
+│  ┌─────────────────────────────┐│
+│  │   Enter Manually Instead    ││
+│  └─────────────────────────────┘│
+└─────────────────────────────────┘
+
+Step 4: ActivityConfirmationModal
 ┌─────────────────────────────────┐
 │  Confirm Activities             │
 ├─────────────────────────────────┤
 │                                 │
 │  You said:                      │
-│  "She fed 60ml formula at 2pm,  │
+│  "She fed 60ml formula at 2pm, │
 │   pooped, and is sleeping now"  │
 │                                 │
-│  I understood:                  │
+│  ⚠ Warnings (if any)           │
 │                                 │
 │  🍼 Feed - 60ml formula         │
 │     2:00 PM - 2:45 PM           │
@@ -1471,39 +1277,97 @@ Confirmation Modal:
 │  😴 Sleep - Started 2:30 PM     │
 │     (ongoing)                   │
 │                                 │
-│  [✓ Confirm & Save]             │
 │  [↻ Re-record]                  │
-│  [✕ Cancel]                     │
+│  [✓ Confirm & Save]             │
 └─────────────────────────────────┘
 ```
 
-### 8.9 Navigation Structure
+### 8.9 Manual Entry Flow
 
 ```
-App Launch → Check device auth
+ManualEntryModal:
+┌─────────────────────────────────┐
+│  Add Activity                   │
+├─────────────────────────────────┤
+│                                 │
+│  What type?                     │
+│  ┌────────┐┌────────┐┌────────┐│
+│  │  🍼    ││  💩    ││  😴    ││
+│  │ Feed   ││Diaper  ││ Sleep  ││
+│  └────────┘└────────┘└────────┘│
+│                                 │
+│  (Form changes based on type)   │
+│                                 │
+│  Feed form:                     │
+│  ┌─────────────────────────────┐│
+│  │ Time: [datetime picker]     ││
+│  │ Amount (ml): [___]          ││
+│  │ Type: [Formula] [Breast]    ││
+│  └─────────────────────────────┘│
+│                                 │
+│  Diaper form:                   │
+│  ┌─────────────────────────────┐│
+│  │ Time: [datetime picker]     ││
+│  │ Pee: [toggle]               ││
+│  │ Poop: [toggle]              ││
+│  └─────────────────────────────┘│
+│                                 │
+│  Sleep form:                    │
+│  ┌─────────────────────────────┐│
+│  │ Start: [datetime picker]    ││
+│  │ Set end time? [toggle]      ││
+│  │ End: [datetime picker]      ││
+│  └─────────────────────────────┘│
+│                                 │
+│  ┌─────────────────────────────┐│
+│  │       Save Activity         ││
+│  └─────────────────────────────┘│
+└─────────────────────────────────┘
+```
+
+**Platform-specific time pickers:**
+- **Web:** `<input type="datetime-local">`
+- **iOS:** Native DateTimePicker (always visible)
+- **Android:** Button opens DateTimePicker in modal
+
+### 8.10 Edit Activity Flow
+
+The EditActivityModal is similar to ManualEntryModal but pre-populated with existing activity data:
+- Available only in CurrentSessionDetailScreen (not for completed sessions)
+- Tap an activity → opens EditActivityModal with current values
+- Title changes based on type: "Edit Feed", "Edit Diaper Change", "Edit Sleep"
+- Save button says "Save Changes"
+
+### 8.11 Navigation Structure
+
+```
+App Launch → Check device auth (AsyncStorage)
 ├─→ No auth → WelcomeScreen
-│   ├─→ Create Family → HomeScreen
-│   └─→ Join Family → HomeScreen
-└─→ Has auth → HomeScreen
-    ├─→ Tap Baby Avatar → SettingsScreen
-    │   ├─→ Leave Family → WelcomeScreen
-    │   └─→ Update Baby Name → HomeScreen
+│   ├─→ Create Family → CreateFamilyScreen → DashboardScreen
+│   └─→ Join Family → JoinFamilyScreen → DashboardScreen
+└─→ Has auth → DashboardScreen
+    ├─→ Tap Caregiver Avatar → SettingsScreen
+    │   └─→ Leave Family → WelcomeScreen
     ├─→ Tap Prediction Card → PredictionDetailScreen
     ├─→ Tap Current Session → CurrentSessionDetailScreen
-    │   └─→ Complete → CompletionModal → HomeScreen
+    │   ├─→ Tap Activity → EditActivityModal
+    │   ├─→ Swipe Activity → Delete
+    │   └─→ Complete → DashboardScreen
     ├─→ Tap Recent Session → SessionDetailScreen (read-only)
-    └─→ Tap Voice Button → VoiceModal → ConfirmationModal → HomeScreen
+    ├─→ Tap Voice Button → VoiceInputModal → ActivityConfirmationModal → DashboardScreen
+    └─→ Tap Manual Button → ManualEntryModal → DashboardScreen
 ```
 
-### 8.10 Avatar Design
+### 8.12 Avatar Design
 
 ```typescript
-// components/FamilyAvatar.tsx
-// Displays baby name with icon, taps to settings
+// components/CaregiverAvatar.tsx
+// Circular badge with caregiver initials (first 2 letters)
+// Color determined by caregiver ID hash (5 fixed color pairs)
+// Tappable → navigates to Settings
 <TouchableOpacity onPress={() => navigate("Settings")}>
-  <View style={styles.avatar}>
-    <Baby size={20} />
-    <Text>{babyName}</Text>
+  <View style={[styles.avatar, { backgroundColor: getCaregiverColor(caregiverId) }]}>
+    <Text>{name.substring(0, 2)}</Text>
   </View>
 </TouchableOpacity>
 ```
@@ -1519,107 +1383,36 @@ App Launch → Check device auth
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
 const KEYS = {
-  DEVICE_ID: "@baby_baton:device_id",
   FAMILY_ID: "@baby_baton:family_id",
   CAREGIVER_ID: "@baby_baton:caregiver_id",
+  CAREGIVER_NAME: "@baby_baton:caregiver_name",
   FAMILY_NAME: "@baby_baton:family_name",
   BABY_NAME: "@baby_baton:baby_name",
 };
 
-class AuthService {
-  async saveAuth(data: {
-    familyId: string;
-    caregiverId: string;
-    familyName: string;
-    babyName: string;
-  }) {
-    await AsyncStorage.multiSet([
-      [KEYS.FAMILY_ID, data.familyId],
-      [KEYS.CAREGIVER_ID, data.caregiverId],
-      [KEYS.FAMILY_NAME, data.familyName],
-      [KEYS.BABY_NAME, data.babyName],
-    ]);
-  }
-
-  async getAuth() {
-    const keys = await AsyncStorage.multiGet([
-      KEYS.FAMILY_ID,
-      KEYS.CAREGIVER_ID,
-      KEYS.FAMILY_NAME,
-      KEYS.BABY_NAME,
-    ]);
-
-    const [familyId, caregiverId, familyName, babyName] = keys.map((k) => k[1]);
-
-    if (!familyId || !caregiverId) return null;
-
-    return { familyId, caregiverId, familyName, babyName };
-  }
-
-  async clearAuth() {
-    await AsyncStorage.multiRemove([
-      KEYS.FAMILY_ID,
-      KEYS.CAREGIVER_ID,
-      KEYS.FAMILY_NAME,
-      KEYS.BABY_NAME,
-    ]);
-  }
-
-  async getDeviceId(): Promise<string> {
-    let deviceId = await AsyncStorage.getItem(KEYS.DEVICE_ID);
-    if (!deviceId) {
-      deviceId = await DeviceInfo.getUniqueId();
-      await AsyncStorage.setItem(KEYS.DEVICE_ID, deviceId);
-    }
-    return deviceId;
-  }
-}
-
-export default new AuthService();
+// saveAuth, getAuth, clearAuth, isAuthenticated methods
+// Device ID managed separately in deviceService.ts
 ```
 
-### 9.2 Authentication Flow
+### 9.2 Device Service
 
 ```typescript
-// hooks/useAuth.ts
-import { useState, useEffect } from "react";
-import authService from "../services/authService";
+// services/deviceService.ts
+// Generates UUID on first run, persists to AsyncStorage
+// Device name detection:
+//   - Web: browser detection (Chrome, Safari, Firefox, Edge)
+//   - iOS/Android: expo-device (modelName or deviceName)
+// Methods: getDeviceId(), getDeviceName(), clearDeviceId()
+```
 
-export const useAuth = () => {
-  const [isLoading, setIsLoading] = useState(true);
-  const [auth, setAuth] = useState(null);
+### 9.3 Authentication Flow
 
-  useEffect(() => {
-    loadAuth();
-  }, []);
-
-  const loadAuth = async () => {
-    const savedAuth = await authService.getAuth();
-    setAuth(savedAuth);
-    setIsLoading(false);
-  };
-
-  const login = async (familyId, caregiverId, familyName, babyName) => {
-    await authService.saveAuth({ familyId, caregiverId, familyName, babyName });
-    setAuth({ familyId, caregiverId, familyName, babyName });
-  };
-
-  const logout = async () => {
-    await authService.clearAuth();
-    setAuth(null);
-  };
-
-  return {
-    isLoading,
-    isAuthenticated: !!auth,
-    familyId: auth?.familyId,
-    caregiverId: auth?.caregiverId,
-    familyName: auth?.familyName,
-    babyName: auth?.babyName,
-    login,
-    logout,
-  };
-};
+```typescript
+// contexts/AuthContext.tsx
+// Provides: isLoading, isAuthenticated, authData, login(), logout()
+// Auth data persisted to AsyncStorage via authService
+// Headers injected via Apollo Client link:
+//   X-Family-ID, X-Caregiver-ID, X-Timezone
 ```
 
 ---
@@ -1661,17 +1454,17 @@ export const useAuth = () => {
 
 # Join family
 ✓ Join existing family with correct password
+✓ Re-join same family from same device (re-auth)
 ✗ Join non-existent family
 ✗ Join with incorrect password
-✗ Join when device already in a family
+✗ Join different family when device already in a family
 
 # Leave family
-✓ Leave family (caregiver deleted, sessions remain)
+✓ Leave family (caregiver + sessions cascade-deleted)
 ✓ After leaving, device can join another family
 
 # Update baby name
-✓ Any caregiver can update baby name
-✓ Baby name updated shows immediately for all devices
+✓ Any caregiver can update baby name (backend only — not yet wired in UI)
 ```
 
 ---
@@ -1680,10 +1473,10 @@ export const useAuth = () => {
 
 | Metric                  | Target      | Notes                                 |
 | ----------------------- | ----------- | ------------------------------------- |
-| Voice parse latency     | < 5 seconds | Speech-to-text + Claude API + DB save |
+| Voice parse latency     | < 5 seconds | Audio upload + Whisper + Claude + return |
 | GraphQL query response  | < 500ms     | Dashboard query with joins            |
-| Poll interval           | 5 minutes   | Configurable                          |
-| Notification scheduling | < 1 second  | Local notification                    |
+| Current session poll    | 10 seconds  | Apollo pollInterval                   |
+| Recent sessions poll    | 30 seconds  | Apollo pollInterval                   |
 | App cold start          | < 2 seconds | To interactive state                  |
 | Memory usage            | < 150MB     | React Native baseline                 |
 | Family auth check       | < 100ms     | Cached in AsyncStorage                |
@@ -1692,28 +1485,17 @@ export const useAuth = () => {
 
 ## 12. Security Considerations
 
-### 12.1 Authentication (Family-Based)
+### 12.1 Authentication (Device-Based)
 
-```typescript
-import DeviceInfo from "react-native-device-info";
-import AsyncStorage from "@react-native-async-storage/async-storage";
-
-const getDeviceAuth = async () => {
-  const deviceId = await DeviceInfo.getUniqueId();
-  const auth = await AsyncStorage.getItem("@baby_baton:auth");
-
-  return {
-    deviceId,
-    familyId: auth?.familyId,
-    caregiverId: auth?.caregiverId,
-  };
-};
-```
+- Device ID generated as UUID on first launch, stored in AsyncStorage
+- Family ID and Caregiver ID sent as HTTP headers on every request
+- No JWTs, sessions, or OAuth — this is an MVP tradeoff
+- Headers: `X-Family-ID`, `X-Caregiver-ID`, `X-Timezone`
 
 ### 12.2 Password Security
 
-- Passwords hashed with bcrypt (cost 10)
-- Plain text displayed in settings for sharing
+- Passwords hashed with bcrypt (default cost)
+- Plain text stored in `password` column and displayed in settings for sharing
 - Min 6 characters (family-friendly, not high security)
 - No password recovery (intentional - ask family member)
 
@@ -1725,21 +1507,22 @@ const getDeviceAuth = async () => {
 
 ### 12.4 API Security
 
-- Local network only (MVP)
-- No JWT tokens yet (device-based auth via deviceId)
+- Backend deployed on Railway (public internet, HTTPS)
+- CORS configured with allowed origins
+- No JWT tokens yet (device-based auth via headers)
 - Future: JWT tokens scoping to family
 
 ### 12.5 Data Privacy
 
-- All data on local server (MacBook)
-- No cloud sync in MVP
-- Optional: encrypted backups to iCloud/Google Drive
+- Backend data stored in Railway PostgreSQL (production)
+- Local PostgreSQL via Docker (development)
+- API keys (Claude, OpenAI) stored in backend `.env` — never logged, committed, or exposed
 
 ---
 
 ## 13. Deployment Configuration
 
-### 13.1 Docker Compose (Local Development)
+### 13.1 Docker Compose (Local Development — PostgreSQL Only)
 
 ```yaml
 # docker-compose.yml
@@ -1757,59 +1540,62 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./migrations:/docker-entrypoint-initdb.d
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s
       timeout: 5s
       retries: 5
 
-  api:
-    build:
-      context: ./backend
-      dockerfile: Dockerfile
-    container_name: baby-baton-api
-    environment:
-      DATABASE_URL: postgres://postgres:postgres@postgres:5432/baby_baton?sslmode=disable
-      CLAUDE_API_KEY: ${CLAUDE_API_KEY}
-      PORT: 8080
-      GIN_MODE: debug
-    ports:
-      - "8080:8080"
-    depends_on:
-      postgres:
-        condition: service_healthy
-    volumes:
-      - ./backend:/app
-    command: ["go", "run", "cmd/server/main.go"]
-
 volumes:
   postgres_data:
 ```
 
-### 13.2 Environment Variables
+**Note:** Only PostgreSQL runs in Docker. The backend runs locally with `go run server.go` during development. Migrations are applied manually.
+
+### 13.2 Railway Deployment (Production)
+
+- **Backend:** Deployed via `backend/Dockerfile` (multi-stage Go build). Production URL: `babybaton-production.up.railway.app`
+- **Frontend (web):** Deployed via `frontend/Dockerfile` (Expo static web export served by `serve`). Production URL: `baby-baton-production.up.railway.app`
+
+### 13.3 EAS (Native Builds)
+
+- **Build profiles** in `eas.json`:
+  - `development` — local dev, points to localhost:8080
+  - `preview` — internal distribution, points to Railway backend
+  - `production` — production distribution, points to Railway backend
+- **OTA Updates:** EAS Update for JS bundle updates without rebuilding native app
+
+### 13.4 CI/CD (GitHub Actions)
+
+- **`ci.yml`** — Runs on every push to main and every PR:
+  - Frontend: `npm ci` → `typecheck` → `jest --ci` (Node 20)
+  - Backend: `go build` → `go test` with real PostgreSQL service container (Go 1.25.3)
+- **`deploy-frontend.yml`** — Runs on push to main when frontend/ changes:
+  - Publishes EAS Update to `preview` channel for OTA
+- **`pr-preview.yml`** — Runs on PRs that touch frontend/:
+  - Publishes preview update on per-PR branch, posts QR code comment
+- **`eas-build.yml`** — Manual trigger (workflow_dispatch):
+  - Builds native iOS/Android apps via EAS Build
+
+### 13.5 Environment Variables
 
 ```bash
-# .env.example
-# Database
+# Backend .env
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/baby_baton?sslmode=disable
-
-# Claude API
-CLAUDE_API_KEY=sk-ant-api03-your-key-here
-
-# Server
 PORT=8080
-GIN_MODE=debug
+CLAUDE_API_KEY=sk-ant-api03-your-key-here
+OPENAI_API_KEY=sk-your-openai-key-here
+CORS_ALLOWED_ORIGIN=http://localhost:8081,https://baby-baton-production.up.railway.app
 
-# Mobile App (for development)
-API_URL=http://192.168.1.100:8080/graphql
+# Frontend (set at EAS build time in eas.json)
+EXPO_PUBLIC_API_URL=http://localhost:8080/query  # varies by build profile
 ```
 
 ---
 
-## 14. Getting Claude API Key
+## 14. Getting API Keys
 
-### 14.1 Setup Steps
+### 14.1 Claude API Key (Voice Parsing)
 
 1. Visit: https://console.anthropic.com
 2. Create account / Sign in
@@ -1818,70 +1604,77 @@ API_URL=http://192.168.1.100:8080/graphql
 5. Copy the key (starts with `sk-ant-api03-...`)
 6. Add to `backend/.env`: `CLAUDE_API_KEY=sk-ant-api03-your-actual-key-here`
 
-### 14.2 Cost Estimate
+### 14.2 OpenAI API Key (Whisper Transcription)
 
-**Voice parsing usage:**
+1. Visit: https://platform.openai.com
+2. Create account / Sign in
+3. Navigate to API Keys
+4. Click "Create new secret key" → Name it "Baby Baton Whisper"
+5. Copy the key (starts with `sk-...`)
+6. Add to `backend/.env`: `OPENAI_API_KEY=sk-your-actual-key-here`
 
-- Average parse: ~200 tokens input, ~500 tokens output
-- Claude Sonnet 4 pricing: $3/M input tokens, $15/M output tokens
-- Cost per parse: ~$0.0081
-- 100 parses/month: ~$0.81
-- 500 parses/month: ~$4.05
+### 14.3 Cost Estimate
+
+**Voice parsing usage (per parse = Whisper + Claude):**
+
+- Whisper: ~$0.006/minute of audio (typically < 30 seconds per input)
+- Claude Sonnet 4.6: ~200 tokens input, ~500 tokens output ≈ $0.008/parse
+- Total per parse: ~$0.01
+- 100 parses/month: ~$1.00
+- 500 parses/month: ~$5.00
 
 ---
 
 ## 15. Development Workflow
 
-### Phase 1: Database & Backend Foundation (Week 1-2)
+### Phase 1: Database & Backend Foundation (Week 1-2) ✅
 
 1. Set up Go project structure
 2. Implement PostgreSQL schema with family tables
-3. Build family authentication service
+3. Build family authentication (header-based)
 4. Create GraphQL resolvers for family operations
 5. Test family create/join/leave flows
 
-### Phase 2: Core Backend Features (Week 2-3)
+### Phase 2: Core Backend Features (Week 2-3) ✅
 
 1. Implement care session management
 2. Build activity tracking with family scoping
-3. Integrate Claude API for voice parsing
-4. Implement prediction algorithm
-5. Test with curl/Postman
+3. Integrate OpenAI Whisper + Claude API for voice parsing
+4. Implement activity CRUD (add, update, delete, end)
+5. Test with GraphQL playground
 
-### Phase 3: Mobile Foundation (Week 3-4)
+### Phase 3: Frontend Foundation (Week 3-4) ✅
 
-1. Set up React Native project
-2. Build welcome & authentication screens
+1. Set up Expo/React Native project
+2. Build welcome, create family, & join family screens
 3. Implement device auth with AsyncStorage
-4. Create family create/join flows
-5. Build settings screen
-6. Test on real devices
+4. Build settings screen
+5. Test on web, iOS, Android
 
-### Phase 4: Mobile Core Features (Week 4-5)
+### Phase 4: Frontend Core Features (Week 4-5) ✅
 
-1. Build home dashboard
-2. Implement voice recording
-3. Create care session screens
-4. Add activity management
-5. Connect to real backend API
-6. Implement local notifications
+1. Build dashboard with prediction, current session, recent sessions
+2. Implement voice recording + upload
+3. Build manual entry modal as fallback
+4. Create care session detail screens (current + completed)
+5. Add activity editing and swipe-to-delete
+6. Connect to real backend API
 
-### Phase 5: Integration & Testing (Week 5-6)
+### Phase 5: Deployment & CI/CD (Week 5-6) ✅
 
-1. End-to-end testing
-2. Multi-device testing
-3. Family switching scenarios
-4. Voice parsing accuracy
-5. Notification reliability
+1. Deploy backend to Railway
+2. Deploy frontend web to Railway
+3. Set up EAS builds for native iOS/Android
+4. Configure GitHub Actions CI/CD
+5. Set up PR preview with QR codes
 
-### Phase 6: Polish & Launch (Week 6)
+### Phase 6: Polish & Ongoing
 
 1. UI/UX refinements
 2. Bug fixes
-3. Documentation
-4. Deploy to local MacBook
-5. Test with real family members
-6. Prepare for open source
+3. Implement feed prediction algorithm (currently mock)
+4. Implement local notifications (not yet built)
+5. Multi-device testing
 
 ---
 
@@ -1892,12 +1685,16 @@ API_URL=http://192.168.1.100:8080/graphql
 - **One baby per family** - No multi-baby support
 - **No roles/permissions** - All caregivers are equal admins
 - **No QR code joining** - Manual name + password entry
-- **Orphaned sessions** - When caregiver leaves, their sessions remain
-- **Device-based auth** - No proper user accounts
-- **Local only** - No cloud backup or sync
+- **Device-based auth** - No proper user accounts (headers only, no JWTs)
+- **Mock predictions** - Feed prediction returns hardcoded mock data
+- **No notifications** - Local notification system not yet built
+- **Baby name not editable in UI** - Backend mutation exists but not wired up in settings
 
 ### Post-MVP Improvements:
 
+- Implement real feed prediction algorithm (Section 4)
+- Implement local notification system (Section 5)
+- Wire up baby name editing in settings UI
 - Multi-baby support within a family
 - Caregiver roles (admin, viewer, etc.)
 - QR code for easy family joining
@@ -2023,6 +1820,53 @@ query GetDashboard {
     predictedTime
     confidence
     reasoning
+  }
+}
+```
+
+### Parse Voice Input
+
+```graphql
+mutation ParseVoice($audioFile: Upload!) {
+  parseVoiceInput(audioFile: $audioFile) {
+    success
+    rawText
+    parsedActivities {
+      activityType
+      feedDetails {
+        startTime
+        amountMl
+        feedType
+      }
+      diaperDetails {
+        changedAt
+        hadPoop
+        hadPee
+      }
+      sleepDetails {
+        startTime
+        endTime
+        isActive
+      }
+    }
+    errors
+  }
+}
+```
+
+### Update Activity
+
+```graphql
+mutation UpdateActivity($activityId: ID!, $input: ActivityInput!) {
+  updateActivity(activityId: $activityId, input: $input) {
+    ... on FeedActivity {
+      id
+      feedDetails {
+        startTime
+        amountMl
+        feedType
+      }
+    }
   }
 }
 ```


### PR DESCRIPTION
The design doc had drifted significantly from the codebase. This brings all sections in sync with what was actually built.

Key changes:
- Voice input: text-based → audio file upload (Whisper + Claude pipeline)
- GraphQL schema: UUID→ID scalar, added Upload, ParsedActivity type, updateActivity mutation, password field on Family
- Backend structure: flat resolvers (no service layer), store interface pattern, mapper layer, Whisper client
- Frontend structure: mobile/→frontend/, actual component/screen names, removed planned-but-unbuilt services and hooks
- Caregiver leave: sessions now cascade-delete (not orphaned)
- Added manual entry and edit activity flows (not in original doc)
- Marked predictions and notifications as NOT YET IMPLEMENTED
- Updated deployment: Railway + EAS + GitHub Actions CI/CD
- Updated polling intervals, env vars, API key setup, cost estimates
- Corrected navigation structure and UI mockups

Closes #21