### PR TITLE
Add database migration runner with tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,7 @@ jobs:
           cache-dependency-path: backend/go.sum
 
       - name: Run migrations
-        run: |
-          PGPASSWORD=postgres psql -h localhost -U postgres -d baby_baton_test -f ../migrations/001_init_schema.sql
-          PGPASSWORD=postgres psql -h localhost -U postgres -d baby_baton_test -f ../migrations/002_add_password_to_families.sql
+        run: ../scripts/migrate.sh "postgres://postgres:postgres@localhost:5432/baby_baton_test?sslmode=disable" ../migrations
 
       - run: go build ./...
       - run: go test -v -count=1 ./...

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Database migration runner
+# Usage: ./scripts/migrate.sh <database_url> <migrations_dir>
+#
+# Tracks applied migrations in a `schema_migrations` table.
+# On first run against an existing database, bootstraps known migrations as already applied.
+
+set -euo pipefail
+
+DATABASE_URL="${1:?Usage: migrate.sh <database_url> <migrations_dir>}"
+MIGRATIONS_DIR="${2:?Usage: migrate.sh <database_url> <migrations_dir>}"
+
+# Create schema_migrations table if it doesn't exist
+psql "$DATABASE_URL" -q -c "
+  CREATE TABLE IF NOT EXISTS schema_migrations (
+    filename VARCHAR(255) PRIMARY KEY,
+    applied_at TIMESTAMP NOT NULL DEFAULT NOW()
+  );
+"
+
+# Bootstrap: if schema_migrations is empty but known tables exist,
+# seed existing migrations as already applied
+MIGRATION_COUNT=$(psql "$DATABASE_URL" -t -c "SELECT COUNT(*) FROM schema_migrations;" | xargs)
+
+if [ "$MIGRATION_COUNT" = "0" ]; then
+  # Check if the database already has tables from previous migrations
+  # (i.e., this is an existing database without schema_migrations tracking)
+  TABLE_EXISTS=$(psql "$DATABASE_URL" -t -c "
+    SELECT EXISTS (
+      SELECT 1 FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name != 'schema_migrations'
+    );
+  " | xargs)
+
+  if [ "$TABLE_EXISTS" = "t" ]; then
+    echo "Bootstrapping: existing database detected, seeding applied migrations..."
+    # Find all migrations that correspond to existing schema objects
+    # by checking which migration files exist in the directory
+    # and marking them all as applied (since the DB already has their changes)
+    for f in $(ls "$MIGRATIONS_DIR"/*.sql 2>/dev/null | sort); do
+      BASENAME=$(basename "$f")
+      psql "$DATABASE_URL" -q -c "
+        INSERT INTO schema_migrations (filename) VALUES ('$BASENAME')
+        ON CONFLICT DO NOTHING;
+      "
+      echo "  Bootstrapped: $BASENAME"
+    done
+    echo "Bootstrap complete."
+    exit 0
+  fi
+fi
+
+# Apply pending migrations in filename order
+APPLIED=0
+for f in $(ls "$MIGRATIONS_DIR"/*.sql 2>/dev/null | sort); do
+  BASENAME=$(basename "$f")
+
+  ALREADY_APPLIED=$(psql "$DATABASE_URL" -t -c "
+    SELECT COUNT(*) FROM schema_migrations WHERE filename = '$BASENAME';
+  " | xargs)
+
+  if [ "$ALREADY_APPLIED" = "0" ]; then
+    echo "Applying: $BASENAME"
+    if ! psql "$DATABASE_URL" --set ON_ERROR_STOP=1 -q -f "$f"; then
+      echo "FAILED: $BASENAME"
+      exit 1
+    fi
+    psql "$DATABASE_URL" -q -c "INSERT INTO schema_migrations (filename) VALUES ('$BASENAME');"
+    echo "Applied: $BASENAME"
+    APPLIED=$((APPLIED + 1))
+  else
+    echo "Skipping (already applied): $BASENAME"
+  fi
+done
+
+echo "Migrations complete. $APPLIED new migration(s) applied."

--- a/scripts/test_migrate.sh
+++ b/scripts/test_migrate.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# Tests for the migration runner script.
+# Requires a running PostgreSQL instance (uses DATABASE_URL or defaults to local).
+#
+# Usage: ./scripts/test_migrate.sh
+
+set -euo pipefail
+
+DATABASE_URL="${DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/migrate_test}"
+MIGRATE_SCRIPT="$(dirname "$0")/migrate.sh"
+MIGRATIONS_DIR="$(mktemp -d)"
+PASS=0
+FAIL=0
+
+cleanup() {
+  rm -rf "$MIGRATIONS_DIR"
+  psql "$DATABASE_URL" -c "DROP DATABASE IF EXISTS migrate_test;" 2>/dev/null || true
+}
+
+setup_db() {
+  # Create a fresh test database
+  local base_url="${DATABASE_URL%/*}"
+  psql "$base_url/postgres" -c "DROP DATABASE IF EXISTS migrate_test;" 2>/dev/null || true
+  psql "$base_url/postgres" -c "CREATE DATABASE migrate_test;" 2>/dev/null || true
+}
+
+assert_eq() {
+  local description="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $description"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $description (expected '$expected', got '$actual')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+run_test() {
+  local test_name="$1"
+  echo ""
+  echo "=== $test_name ==="
+}
+
+# --- Setup ---
+setup_db
+
+# Reconstruct DATABASE_URL to point to migrate_test db
+BASE_URL="${DATABASE_URL%/*}"
+TEST_DB_URL="$BASE_URL/migrate_test"
+
+# --- Test 1: Fresh database, all migrations applied ---
+run_test "Test 1: Fresh database — runs all migrations"
+
+cat > "$MIGRATIONS_DIR/001_create_users.sql" << 'SQL'
+CREATE TABLE users (id SERIAL PRIMARY KEY, name VARCHAR(100));
+SQL
+
+cat > "$MIGRATIONS_DIR/002_add_email.sql" << 'SQL'
+ALTER TABLE users ADD COLUMN email VARCHAR(200);
+SQL
+
+bash "$MIGRATE_SCRIPT" "$TEST_DB_URL" "$MIGRATIONS_DIR"
+
+MIGRATION_COUNT=$(psql "$TEST_DB_URL" -t -c "SELECT COUNT(*) FROM schema_migrations;" | xargs)
+assert_eq "schema_migrations has 2 entries" "2" "$MIGRATION_COUNT"
+
+TABLE_EXISTS=$(psql "$TEST_DB_URL" -t -c "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'users');" | xargs)
+assert_eq "users table was created" "t" "$TABLE_EXISTS"
+
+COL_EXISTS=$(psql "$TEST_DB_URL" -t -c "SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'email');" | xargs)
+assert_eq "email column was added" "t" "$COL_EXISTS"
+
+# --- Test 2: Idempotent — running again skips all ---
+run_test "Test 2: Idempotent — running again applies nothing"
+
+bash "$MIGRATE_SCRIPT" "$TEST_DB_URL" "$MIGRATIONS_DIR"
+
+MIGRATION_COUNT=$(psql "$TEST_DB_URL" -t -c "SELECT COUNT(*) FROM schema_migrations;" | xargs)
+assert_eq "schema_migrations still has 2 entries" "2" "$MIGRATION_COUNT"
+
+# --- Test 3: New migration — only new one is applied ---
+run_test "Test 3: New migration — only new one applied"
+
+cat > "$MIGRATIONS_DIR/003_add_age.sql" << 'SQL'
+ALTER TABLE users ADD COLUMN age INTEGER;
+SQL
+
+bash "$MIGRATE_SCRIPT" "$TEST_DB_URL" "$MIGRATIONS_DIR"
+
+MIGRATION_COUNT=$(psql "$TEST_DB_URL" -t -c "SELECT COUNT(*) FROM schema_migrations;" | xargs)
+assert_eq "schema_migrations has 3 entries" "3" "$MIGRATION_COUNT"
+
+COL_EXISTS=$(psql "$TEST_DB_URL" -t -c "SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'age');" | xargs)
+assert_eq "age column was added" "t" "$COL_EXISTS"
+
+# --- Test 4: Bootstrap — existing tables, no schema_migrations ---
+run_test "Test 4: Bootstrap — seeds existing migrations"
+
+# Drop schema_migrations to simulate first run on existing DB
+psql "$TEST_DB_URL" -c "DROP TABLE schema_migrations;" > /dev/null
+
+bash "$MIGRATE_SCRIPT" "$TEST_DB_URL" "$MIGRATIONS_DIR"
+
+MIGRATION_COUNT=$(psql "$TEST_DB_URL" -t -c "SELECT COUNT(*) FROM schema_migrations;" | xargs)
+assert_eq "schema_migrations has 3 entries after bootstrap" "3" "$MIGRATION_COUNT"
+
+# --- Test 5: Failed migration — exits with error ---
+run_test "Test 5: Failed migration — exits non-zero"
+
+cat > "$MIGRATIONS_DIR/004_bad_migration.sql" << 'SQL'
+THIS IS NOT VALID SQL;
+SQL
+
+set +e
+bash "$MIGRATE_SCRIPT" "$TEST_DB_URL" "$MIGRATIONS_DIR" 2>/dev/null
+EXIT_CODE=$?
+set -e
+
+assert_eq "exits with non-zero on bad migration" "1" "$EXIT_CODE"
+
+BAD_APPLIED=$(psql "$TEST_DB_URL" -t -c "SELECT COUNT(*) FROM schema_migrations WHERE filename = '004_bad_migration.sql';" | xargs)
+assert_eq "bad migration not recorded" "0" "$BAD_APPLIED"
+
+# Clean up bad migration for subsequent runs
+rm "$MIGRATIONS_DIR/004_bad_migration.sql"
+
+# --- Summary ---
+echo ""
+echo "================================"
+echo "Results: $PASS passed, $FAIL failed"
+echo "================================"
+
+cleanup
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `scripts/migrate.sh` — a migration runner that tracks applied migrations in a `schema_migrations` table
- Add `scripts/test_migrate.sh` — 9 test cases for the runner
- Update CI to use `migrate.sh` instead of hardcoded migration commands (fixes missing migration 003)

## What the migration runner does
1. Creates `schema_migrations` table if it doesn't exist
2. Bootstraps existing databases (seeds all migrations as applied if tables already exist)
3. Applies only pending `.sql` files in filename order
4. Fails fast if any migration errors — prevents partial state

## Test plan
- [x] 9 local tests pass: fresh DB, idempotency, incremental, bootstrap, failure handling
- [x] CI passes with the new migration approach (replaces hardcoded `psql` commands)

Part of #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)