### PR TITLE
Add deploy workflow: migrate then deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Deploy backend
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-        run: railway redeploy --service ${{ secrets.BACKEND_SERVICE_ID }} --yes
+        run: railway up --ci --service ${{ secrets.BACKEND_SERVICE_ID }}
 
       - name: Deploy frontend
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-        run: railway redeploy --service ${{ secrets.FRONTEND_SERVICE_ID }} --yes
+        run: railway up --ci --service ${{ secrets.FRONTEND_SERVICE_ID }}


### PR DESCRIPTION
## Summary
Adds a GitHub Actions deploy workflow that runs on push to main (and manual dispatch):
1. Runs pending database migrations against Railway PostgreSQL
2. Deploys backend via Railway CLI
3. Deploys frontend via Railway CLI

If any migration fails, the workflow stops and no deploys are triggered.

## Secrets used
- `DATABASE_PUBLIC_URL` — Railway PostgreSQL connection string
- `RAILWAY_TOKEN` — Railway project token
- `BACKEND_SERVICE_ID` — Railway backend service ID
- `FRONTEND_SERVICE_ID` — Railway frontend service ID

## Important
After merging, **disable Railway auto-deploy** for both backend and frontend services so deploys are controlled exclusively by this workflow.

## Test plan
- [x] CI passes
- [ ] After merge, workflow runs on push to main
- [ ] Migrations step shows "Skipping (already applied)" for existing migrations
- [ ] Both services redeploy successfully on Railway

Part of #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)