### PR TITLE
Fix deploy workflow: use npm install for Railway CLI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Run pending migrations
         run: ./scripts/migrate.sh "${{ secrets.DATABASE_PUBLIC_URL }}" ./migrations
 
-      - name: Setup Railway CLI
-        uses: railwayapp/setup-cli@v1
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
 
       - name: Deploy backend
         env:


### PR DESCRIPTION
## Summary
The `railwayapp/setup-cli@v1` action doesn't exist, causing the deploy workflow to fail. Replaces with `npm install -g @railway/cli`.

## Test plan
- [ ] Deploy workflow passes after merge

Part of #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)