### PR TITLE
Fix #33: Add solids tracking to feed activity: database schema

### DIFF
--- a/backend/internal/domain/models.go
+++ b/backend/internal/domain/models.go
@@ -27,6 +27,7 @@ type FeedType string
 const (
 	FeedTypeBreastMilk FeedType = "breast_milk"
 	FeedTypeFormula    FeedType = "formula"
+	FeedTypeSolids     FeedType = "solids"
 )
 
 // Domain Models
@@ -72,14 +73,17 @@ type Activity struct {
 }
 
 type FeedDetails struct {
-	ID         uuid.UUID
-	ActivityID uuid.UUID
-	StartTime  time.Time
-	EndTime    *time.Time
-	AmountMl   *int
-	FeedType   *FeedType
-	CreatedAt  time.Time
-	UpdatedAt  time.Time
+	ID           uuid.UUID
+	ActivityID   uuid.UUID
+	StartTime    time.Time
+	EndTime      *time.Time
+	AmountMl     *int
+	FeedType     *FeedType
+	FoodName     *string
+	Quantity     *float64
+	QuantityUnit *string
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
 }
 
 type DiaperDetails struct {

--- a/backend/internal/store/postgres/activity_details.go
+++ b/backend/internal/store/postgres/activity_details.go
@@ -16,9 +16,9 @@ import (
 // CreateFeedDetails creates feed details for an activity
 func (s *PostgresStore) CreateFeedDetails(ctx context.Context, details *domain.FeedDetails) error {
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO feed_details (id, activity_id, start_time, end_time, amount_ml, feed_type, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-	`, details.ID, details.ActivityID, details.StartTime, details.EndTime, details.AmountMl, details.FeedType, details.CreatedAt, details.UpdatedAt)
+		INSERT INTO feed_details (id, activity_id, start_time, end_time, amount_ml, feed_type, food_name, quantity, quantity_unit, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+	`, details.ID, details.ActivityID, details.StartTime, details.EndTime, details.AmountMl, details.FeedType, details.FoodName, details.Quantity, details.QuantityUnit, details.CreatedAt, details.UpdatedAt)
 
 	if err != nil {
 		return fmt.Errorf("failed to create feed details: %w", err)
@@ -32,7 +32,7 @@ func (s *PostgresStore) GetFeedDetails(ctx context.Context, activityID uuid.UUID
 	details := &domain.FeedDetails{}
 
 	err := s.db.QueryRowContext(ctx, `
-		SELECT id, activity_id, start_time, end_time, amount_ml, feed_type, created_at, updated_at
+		SELECT id, activity_id, start_time, end_time, amount_ml, feed_type, food_name, quantity, quantity_unit, created_at, updated_at
 		FROM feed_details
 		WHERE activity_id = $1
 	`, activityID).Scan(
@@ -42,6 +42,9 @@ func (s *PostgresStore) GetFeedDetails(ctx context.Context, activityID uuid.UUID
 		&details.EndTime,
 		&details.AmountMl,
 		&details.FeedType,
+		&details.FoodName,
+		&details.Quantity,
+		&details.QuantityUnit,
 		&details.CreatedAt,
 		&details.UpdatedAt,
 	)
@@ -147,7 +150,7 @@ func (s *PostgresStore) GetSleepDetails(ctx context.Context, activityID uuid.UUI
 // GetRecentFeedDetailsForFamily retrieves recent feed details across all sessions for a family
 func (s *PostgresStore) GetRecentFeedDetailsForFamily(ctx context.Context, familyID uuid.UUID, limit int) ([]*domain.FeedDetails, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT fd.id, fd.activity_id, fd.start_time, fd.end_time, fd.amount_ml, fd.feed_type, fd.created_at, fd.updated_at
+		SELECT fd.id, fd.activity_id, fd.start_time, fd.end_time, fd.amount_ml, fd.feed_type, fd.food_name, fd.quantity, fd.quantity_unit, fd.created_at, fd.updated_at
 		FROM feed_details fd
 		JOIN activities a ON fd.activity_id = a.id
 		JOIN care_sessions cs ON a.care_session_id = cs.id
@@ -166,7 +169,8 @@ func (s *PostgresStore) GetRecentFeedDetailsForFamily(ctx context.Context, famil
 		d := &domain.FeedDetails{}
 		err := rows.Scan(
 			&d.ID, &d.ActivityID, &d.StartTime, &d.EndTime,
-			&d.AmountMl, &d.FeedType, &d.CreatedAt, &d.UpdatedAt,
+			&d.AmountMl, &d.FeedType, &d.FoodName, &d.Quantity, &d.QuantityUnit,
+			&d.CreatedAt, &d.UpdatedAt,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan feed details: %w", err)
@@ -185,9 +189,9 @@ func (s *PostgresStore) GetRecentFeedDetailsForFamily(ctx context.Context, famil
 func (s *PostgresStore) UpdateFeedDetails(ctx context.Context, details *domain.FeedDetails) error {
 	result, err := s.db.ExecContext(ctx, `
 		UPDATE feed_details
-		SET start_time = $1, end_time = $2, amount_ml = $3, feed_type = $4, updated_at = $5
-		WHERE id = $6
-	`, details.StartTime, details.EndTime, details.AmountMl, details.FeedType, details.UpdatedAt, details.ID)
+		SET start_time = $1, end_time = $2, amount_ml = $3, feed_type = $4, food_name = $5, quantity = $6, quantity_unit = $7, updated_at = $8
+		WHERE id = $9
+	`, details.StartTime, details.EndTime, details.AmountMl, details.FeedType, details.FoodName, details.Quantity, details.QuantityUnit, details.UpdatedAt, details.ID)
 
 	if err != nil {
 		return fmt.Errorf("failed to update feed details: %w", err)

--- a/backend/internal/store/postgres/solids_schema_test.go
+++ b/backend/internal/store/postgres/solids_schema_test.go
@@ -1,0 +1,236 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/swatkatz/babybaton/backend/internal/domain"
+)
+
+func TestSolidsSchema(t *testing.T) {
+	store, err := NewPostgresStore("postgres://postgres:postgres@localhost:5432/baby_baton_test?sslmode=disable")
+	if err != nil {
+		t.Fatalf("Failed to connect to database: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+
+	// Create unique test family using helper
+	family, caregiver, err := CreateTestFamily(ctx, store)
+	if err != nil {
+		t.Fatalf("Failed to create test family: %v", err)
+	}
+
+	t.Cleanup(func() {
+		store.DeleteFamily(ctx, family.ID)
+	})
+
+	// Create test session
+	session := &domain.CareSession{
+		ID:          uuid.New(),
+		CaregiverID: caregiver.ID,
+		FamilyID:    family.ID,
+		Status:      domain.StatusInProgress,
+		StartedAt:   time.Now(),
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+	err = store.CreateCareSession(ctx, session)
+	if err != nil {
+		t.Fatalf("Failed to create test session: %v", err)
+	}
+
+	// Create feed activity
+	feedActivity := &domain.Activity{
+		ID:            uuid.New(),
+		CareSessionID: session.ID,
+		ActivityType:  domain.ActivityTypeFeed,
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	}
+	err = store.CreateActivity(ctx, feedActivity)
+	if err != nil {
+		t.Fatalf("Failed to create feed activity: %v", err)
+	}
+
+	t.Run("InsertSolidsFeedType", func(t *testing.T) {
+		// Insert a feed_details row with feed_type='solids' — should succeed after migration
+		feedType := domain.FeedTypeSolids
+		feedDetails := &domain.FeedDetails{
+			ID:         uuid.New(),
+			ActivityID: feedActivity.ID,
+			StartTime:  time.Now(),
+			FeedType:   &feedType,
+			FoodName:   stringPtr("carrots"),
+			CreatedAt:  time.Now(),
+			UpdatedAt:  time.Now(),
+		}
+
+		err := store.CreateFeedDetails(ctx, feedDetails)
+		if err != nil {
+			t.Fatalf("Failed to insert solids feed: %v", err)
+		}
+
+		// Retrieve and verify
+		retrieved, err := store.GetFeedDetails(ctx, feedActivity.ID)
+		if err != nil {
+			t.Fatalf("Failed to get feed details: %v", err)
+		}
+		if retrieved.FeedType == nil || *retrieved.FeedType != domain.FeedTypeSolids {
+			t.Errorf("Expected feed type 'solids', got %v", retrieved.FeedType)
+		}
+		if retrieved.FoodName == nil || *retrieved.FoodName != "carrots" {
+			t.Errorf("Expected food_name 'carrots', got %v", retrieved.FoodName)
+		}
+		t.Logf("✓ Inserted and retrieved solids feed: food_name=%s", *retrieved.FoodName)
+	})
+
+	t.Run("InsertSolidsWithQuantity", func(t *testing.T) {
+		// Create another feed activity for this test
+		feedActivity2 := &domain.Activity{
+			ID:            uuid.New(),
+			CareSessionID: session.ID,
+			ActivityType:  domain.ActivityTypeFeed,
+			CreatedAt:     time.Now(),
+			UpdatedAt:     time.Now(),
+		}
+		err := store.CreateActivity(ctx, feedActivity2)
+		if err != nil {
+			t.Fatalf("Failed to create feed activity: %v", err)
+		}
+
+		feedType := domain.FeedTypeSolids
+		quantity := 10.0
+		quantityUnit := "spoons"
+		feedDetails := &domain.FeedDetails{
+			ID:           uuid.New(),
+			ActivityID:   feedActivity2.ID,
+			StartTime:    time.Now(),
+			FeedType:     &feedType,
+			FoodName:     stringPtr("mushed carrots"),
+			Quantity:     &quantity,
+			QuantityUnit: &quantityUnit,
+			CreatedAt:    time.Now(),
+			UpdatedAt:    time.Now(),
+		}
+
+		err = store.CreateFeedDetails(ctx, feedDetails)
+		if err != nil {
+			t.Fatalf("Failed to insert solids feed with quantity: %v", err)
+		}
+
+		retrieved, err := store.GetFeedDetails(ctx, feedActivity2.ID)
+		if err != nil {
+			t.Fatalf("Failed to get feed details: %v", err)
+		}
+		if retrieved.Quantity == nil || *retrieved.Quantity != 10.0 {
+			t.Errorf("Expected quantity 10, got %v", retrieved.Quantity)
+		}
+		if retrieved.QuantityUnit == nil || *retrieved.QuantityUnit != "spoons" {
+			t.Errorf("Expected quantity_unit 'spoons', got %v", retrieved.QuantityUnit)
+		}
+		t.Logf("✓ Inserted solids with quantity: %.0f %s of %s", *retrieved.Quantity, *retrieved.QuantityUnit, *retrieved.FoodName)
+	})
+
+	t.Run("NegativeQuantityFails", func(t *testing.T) {
+		feedActivity3 := &domain.Activity{
+			ID:            uuid.New(),
+			CareSessionID: session.ID,
+			ActivityType:  domain.ActivityTypeFeed,
+			CreatedAt:     time.Now(),
+			UpdatedAt:     time.Now(),
+		}
+		store.CreateActivity(ctx, feedActivity3)
+
+		feedType := domain.FeedTypeSolids
+		negativeQuantity := -1.0
+		feedDetails := &domain.FeedDetails{
+			ID:         uuid.New(),
+			ActivityID: feedActivity3.ID,
+			StartTime:  time.Now(),
+			FeedType:   &feedType,
+			FoodName:   stringPtr("banana"),
+			Quantity:   &negativeQuantity,
+			CreatedAt:  time.Now(),
+			UpdatedAt:  time.Now(),
+		}
+
+		err := store.CreateFeedDetails(ctx, feedDetails)
+		if err == nil {
+			t.Fatal("Expected error for negative quantity, but insert succeeded")
+		}
+		t.Logf("✓ Negative quantity correctly rejected: %v", err)
+	})
+
+	t.Run("InvalidQuantityUnitFails", func(t *testing.T) {
+		feedActivity4 := &domain.Activity{
+			ID:            uuid.New(),
+			CareSessionID: session.ID,
+			ActivityType:  domain.ActivityTypeFeed,
+			CreatedAt:     time.Now(),
+			UpdatedAt:     time.Now(),
+		}
+		store.CreateActivity(ctx, feedActivity4)
+
+		feedType := domain.FeedTypeSolids
+		quantity := 1.0
+		invalidUnit := "cups"
+		feedDetails := &domain.FeedDetails{
+			ID:           uuid.New(),
+			ActivityID:   feedActivity4.ID,
+			StartTime:    time.Now(),
+			FeedType:     &feedType,
+			FoodName:     stringPtr("yogurt"),
+			Quantity:     &quantity,
+			QuantityUnit: &invalidUnit,
+			CreatedAt:    time.Now(),
+			UpdatedAt:    time.Now(),
+		}
+
+		err := store.CreateFeedDetails(ctx, feedDetails)
+		if err == nil {
+			t.Fatal("Expected error for invalid quantity_unit 'cups', but insert succeeded")
+		}
+		t.Logf("✓ Invalid quantity_unit correctly rejected: %v", err)
+	})
+
+	t.Run("FormulaFeedStillWorks", func(t *testing.T) {
+		feedActivity5 := &domain.Activity{
+			ID:            uuid.New(),
+			CareSessionID: session.ID,
+			ActivityType:  domain.ActivityTypeFeed,
+			CreatedAt:     time.Now(),
+			UpdatedAt:     time.Now(),
+		}
+		store.CreateActivity(ctx, feedActivity5)
+
+		feedType := domain.FeedTypeFormula
+		amountMl := 120
+		feedDetails := &domain.FeedDetails{
+			ID:         uuid.New(),
+			ActivityID: feedActivity5.ID,
+			StartTime:  time.Now(),
+			FeedType:   &feedType,
+			AmountMl:   &amountMl,
+			CreatedAt:  time.Now(),
+			UpdatedAt:  time.Now(),
+		}
+
+		err := store.CreateFeedDetails(ctx, feedDetails)
+		if err != nil {
+			t.Fatalf("Failed to insert formula feed (regression): %v", err)
+		}
+
+		retrieved, err := store.GetFeedDetails(ctx, feedActivity5.ID)
+		if err != nil {
+			t.Fatalf("Failed to get formula feed details: %v", err)
+		}
+		if retrieved.AmountMl == nil || *retrieved.AmountMl != 120 {
+			t.Errorf("Expected amount_ml 120, got %v", retrieved.AmountMl)
+		}
+		t.Logf("✓ Formula feed still works: %dml", *retrieved.AmountMl)
+	})
+}

--- a/migrations/005_add_solids.sql
+++ b/migrations/005_add_solids.sql
@@ -1,0 +1,12 @@
+-- Add solids support to feed_details table
+-- Adds food_name, quantity, and quantity_unit columns for tracking solid food feedings
+-- Updates feed_type CHECK constraint to allow 'solids'
+
+-- Add new columns (all nullable — only used for solids feeds)
+ALTER TABLE feed_details ADD COLUMN food_name VARCHAR(200);
+ALTER TABLE feed_details ADD COLUMN quantity DECIMAL(6,2) CHECK (quantity > 0);
+ALTER TABLE feed_details ADD COLUMN quantity_unit VARCHAR(20) CHECK (quantity_unit IN ('spoons', 'bowls', 'pieces', 'portions'));
+
+-- Update feed_type CHECK constraint to include 'solids'
+ALTER TABLE feed_details DROP CONSTRAINT feed_details_feed_type_check;
+ALTER TABLE feed_details ADD CONSTRAINT feed_details_feed_type_check CHECK (feed_type IN ('breast_milk', 'formula', 'solids'));


### PR DESCRIPTION
## Summary

Closes #33

- Add solids tracking schema to feed_details table (#33)

## Test plan

- [ ] Verify the changes address the issue requirements
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)