### PR TITLE
Fix #34: Add solids tracking to feed activity: backend

### DIFF
--- a/backend/graph/generated.go
+++ b/backend/graph/generated.go
@@ -119,6 +119,9 @@ type ComplexityRoot struct {
 		DurationMinutes func(childComplexity int) int
 		EndTime         func(childComplexity int) int
 		FeedType        func(childComplexity int) int
+		FoodName        func(childComplexity int) int
+		Quantity        func(childComplexity int) int
+		QuantityUnit    func(childComplexity int) int
 		StartTime       func(childComplexity int) int
 	}
 
@@ -514,6 +517,24 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.FeedDetails.FeedType(childComplexity), true
+	case "FeedDetails.foodName":
+		if e.complexity.FeedDetails.FoodName == nil {
+			break
+		}
+
+		return e.complexity.FeedDetails.FoodName(childComplexity), true
+	case "FeedDetails.quantity":
+		if e.complexity.FeedDetails.Quantity == nil {
+			break
+		}
+
+		return e.complexity.FeedDetails.Quantity(childComplexity), true
+	case "FeedDetails.quantityUnit":
+		if e.complexity.FeedDetails.QuantityUnit == nil {
+			break
+		}
+
+		return e.complexity.FeedDetails.QuantityUnit(childComplexity), true
 	case "FeedDetails.startTime":
 		if e.complexity.FeedDetails.StartTime == nil {
 			break
@@ -943,6 +964,14 @@ enum ActivityType {
 enum FeedType {
   BREAST_MILK
   FORMULA
+  SOLIDS
+}
+
+enum SolidsUnit {
+  SPOONS
+  BOWLS
+  PIECES
+  PORTIONS
 }
 
 enum PredictionConfidence {
@@ -1000,6 +1029,9 @@ type FeedDetails {
   amountMl: Int
   feedType: FeedType
   durationMinutes: Int
+  foodName: String
+  quantity: Float
+  quantityUnit: SolidsUnit
 }
 
 type DiaperDetails {
@@ -1078,6 +1110,9 @@ input FeedDetailsInput {
   endTime: DateTime
   amountMl: Int
   feedType: FeedType
+  foodName: String
+  quantity: Float
+  quantityUnit: SolidsUnit
 }
 
 input DiaperDetailsInput {
@@ -2736,6 +2771,12 @@ func (ec *executionContext) fieldContext_FeedActivity_feedDetails(_ context.Cont
 				return ec.fieldContext_FeedDetails_feedType(ctx, field)
 			case "durationMinutes":
 				return ec.fieldContext_FeedDetails_durationMinutes(ctx, field)
+			case "foodName":
+				return ec.fieldContext_FeedDetails_foodName(ctx, field)
+			case "quantity":
+				return ec.fieldContext_FeedDetails_quantity(ctx, field)
+			case "quantityUnit":
+				return ec.fieldContext_FeedDetails_quantityUnit(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type FeedDetails", field.Name)
 		},
@@ -2883,6 +2924,93 @@ func (ec *executionContext) fieldContext_FeedDetails_durationMinutes(_ context.C
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _FeedDetails_foodName(ctx context.Context, field graphql.CollectedField, obj *model.FeedDetails) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_FeedDetails_foodName,
+		func(ctx context.Context) (any, error) {
+			return obj.FoodName, nil
+		},
+		nil,
+		ec.marshalOString2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_FeedDetails_foodName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FeedDetails",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _FeedDetails_quantity(ctx context.Context, field graphql.CollectedField, obj *model.FeedDetails) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_FeedDetails_quantity,
+		func(ctx context.Context) (any, error) {
+			return obj.Quantity, nil
+		},
+		nil,
+		ec.marshalOFloat2ᚖfloat64,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_FeedDetails_quantity(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FeedDetails",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _FeedDetails_quantityUnit(ctx context.Context, field graphql.CollectedField, obj *model.FeedDetails) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_FeedDetails_quantityUnit,
+		func(ctx context.Context) (any, error) {
+			return obj.QuantityUnit, nil
+		},
+		nil,
+		ec.marshalOSolidsUnit2ᚖgithubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐSolidsUnit,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_FeedDetails_quantityUnit(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FeedDetails",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type SolidsUnit does not have child fields")
 		},
 	}
 	return fc, nil
@@ -3598,6 +3726,12 @@ func (ec *executionContext) fieldContext_ParsedActivity_feedDetails(_ context.Co
 				return ec.fieldContext_FeedDetails_feedType(ctx, field)
 			case "durationMinutes":
 				return ec.fieldContext_FeedDetails_durationMinutes(ctx, field)
+			case "foodName":
+				return ec.fieldContext_FeedDetails_foodName(ctx, field)
+			case "quantity":
+				return ec.fieldContext_FeedDetails_quantity(ctx, field)
+			case "quantityUnit":
+				return ec.fieldContext_FeedDetails_quantityUnit(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type FeedDetails", field.Name)
 		},
@@ -6036,7 +6170,7 @@ func (ec *executionContext) unmarshalInputFeedDetailsInput(ctx context.Context, 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"startTime", "endTime", "amountMl", "feedType"}
+	fieldsInOrder := [...]string{"startTime", "endTime", "amountMl", "feedType", "foodName", "quantity", "quantityUnit"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -6071,6 +6205,27 @@ func (ec *executionContext) unmarshalInputFeedDetailsInput(ctx context.Context, 
 				return it, err
 			}
 			it.FeedType = data
+		case "foodName":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("foodName"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.FoodName = data
+		case "quantity":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("quantity"))
+			data, err := ec.unmarshalOFloat2ᚖfloat64(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Quantity = data
+		case "quantityUnit":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("quantityUnit"))
+			data, err := ec.unmarshalOSolidsUnit2ᚖgithubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐSolidsUnit(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.QuantityUnit = data
 		}
 	}
 
@@ -6630,6 +6785,12 @@ func (ec *executionContext) _FeedDetails(ctx context.Context, sel ast.SelectionS
 			out.Values[i] = ec._FeedDetails_feedType(ctx, field, obj)
 		case "durationMinutes":
 			out.Values[i] = ec._FeedDetails_durationMinutes(ctx, field, obj)
+		case "foodName":
+			out.Values[i] = ec._FeedDetails_foodName(ctx, field, obj)
+		case "quantity":
+			out.Values[i] = ec._FeedDetails_quantity(ctx, field, obj)
+		case "quantityUnit":
+			out.Values[i] = ec._FeedDetails_quantityUnit(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -8347,6 +8508,23 @@ func (ec *executionContext) marshalOFeedType2ᚖgithubᚗcomᚋswatkatzᚋbabyba
 	return v
 }
 
+func (ec *executionContext) unmarshalOFloat2ᚖfloat64(ctx context.Context, v any) (*float64, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := graphql.UnmarshalFloatContext(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOFloat2ᚖfloat64(ctx context.Context, sel ast.SelectionSet, v *float64) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	_ = sel
+	res := graphql.MarshalFloatContext(*v)
+	return graphql.WrapContextMarshaler(ctx, res)
+}
+
 func (ec *executionContext) unmarshalOInt2ᚖint32(ctx context.Context, v any) (*int32, error) {
 	if v == nil {
 		return nil, nil
@@ -8378,6 +8556,22 @@ func (ec *executionContext) unmarshalOSleepDetailsInput2ᚖgithubᚗcomᚋswatka
 	}
 	res, err := ec.unmarshalInputSleepDetailsInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOSolidsUnit2ᚖgithubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐSolidsUnit(ctx context.Context, v any) (*model.SolidsUnit, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var res = new(model.SolidsUnit)
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOSolidsUnit2ᚖgithubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐSolidsUnit(ctx context.Context, sel ast.SelectionSet, v *model.SolidsUnit) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return v
 }
 
 func (ec *executionContext) unmarshalOString2ᚕstringᚄ(ctx context.Context, v any) ([]string, error) {

--- a/backend/graph/model/models_gen.go
+++ b/backend/graph/model/models_gen.go
@@ -99,18 +99,24 @@ type FeedActivity struct {
 func (FeedActivity) IsActivity() {}
 
 type FeedDetails struct {
-	StartTime       time.Time  `json:"startTime"`
-	EndTime         *time.Time `json:"endTime,omitempty"`
-	AmountMl        *int32     `json:"amountMl,omitempty"`
-	FeedType        *FeedType  `json:"feedType,omitempty"`
-	DurationMinutes *int32     `json:"durationMinutes,omitempty"`
+	StartTime       time.Time   `json:"startTime"`
+	EndTime         *time.Time  `json:"endTime,omitempty"`
+	AmountMl        *int32      `json:"amountMl,omitempty"`
+	FeedType        *FeedType   `json:"feedType,omitempty"`
+	DurationMinutes *int32      `json:"durationMinutes,omitempty"`
+	FoodName        *string     `json:"foodName,omitempty"`
+	Quantity        *float64    `json:"quantity,omitempty"`
+	QuantityUnit    *SolidsUnit `json:"quantityUnit,omitempty"`
 }
 
 type FeedDetailsInput struct {
-	StartTime time.Time  `json:"startTime"`
-	EndTime   *time.Time `json:"endTime,omitempty"`
-	AmountMl  *int32     `json:"amountMl,omitempty"`
-	FeedType  *FeedType  `json:"feedType,omitempty"`
+	StartTime    time.Time   `json:"startTime"`
+	EndTime      *time.Time  `json:"endTime,omitempty"`
+	AmountMl     *int32      `json:"amountMl,omitempty"`
+	FeedType     *FeedType   `json:"feedType,omitempty"`
+	FoodName     *string     `json:"foodName,omitempty"`
+	Quantity     *float64    `json:"quantity,omitempty"`
+	QuantityUnit *SolidsUnit `json:"quantityUnit,omitempty"`
 }
 
 type Mutation struct {
@@ -278,16 +284,18 @@ type FeedType string
 const (
 	FeedTypeBreastMilk FeedType = "BREAST_MILK"
 	FeedTypeFormula    FeedType = "FORMULA"
+	FeedTypeSolids     FeedType = "SOLIDS"
 )
 
 var AllFeedType = []FeedType{
 	FeedTypeBreastMilk,
 	FeedTypeFormula,
+	FeedTypeSolids,
 }
 
 func (e FeedType) IsValid() bool {
 	switch e {
-	case FeedTypeBreastMilk, FeedTypeFormula:
+	case FeedTypeBreastMilk, FeedTypeFormula, FeedTypeSolids:
 		return true
 	}
 	return false
@@ -380,6 +388,65 @@ func (e *PredictionConfidence) UnmarshalJSON(b []byte) error {
 }
 
 func (e PredictionConfidence) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	e.MarshalGQL(&buf)
+	return buf.Bytes(), nil
+}
+
+type SolidsUnit string
+
+const (
+	SolidsUnitSpoons   SolidsUnit = "SPOONS"
+	SolidsUnitBowls    SolidsUnit = "BOWLS"
+	SolidsUnitPieces   SolidsUnit = "PIECES"
+	SolidsUnitPortions SolidsUnit = "PORTIONS"
+)
+
+var AllSolidsUnit = []SolidsUnit{
+	SolidsUnitSpoons,
+	SolidsUnitBowls,
+	SolidsUnitPieces,
+	SolidsUnitPortions,
+}
+
+func (e SolidsUnit) IsValid() bool {
+	switch e {
+	case SolidsUnitSpoons, SolidsUnitBowls, SolidsUnitPieces, SolidsUnitPortions:
+		return true
+	}
+	return false
+}
+
+func (e SolidsUnit) String() string {
+	return string(e)
+}
+
+func (e *SolidsUnit) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = SolidsUnit(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid SolidsUnit", str)
+	}
+	return nil
+}
+
+func (e SolidsUnit) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+func (e *SolidsUnit) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	return e.UnmarshalGQL(s)
+}
+
+func (e SolidsUnit) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
 	e.MarshalGQL(&buf)
 	return buf.Bytes(), nil

--- a/backend/graph/schema.resolvers.go
+++ b/backend/graph/schema.resolvers.go
@@ -412,7 +412,7 @@ func (r *mutationResolver) AddActivities(ctx context.Context, activities []*mode
 				return nil, fmt.Errorf("feed activity requires feedDetails")
 			}
 
-			// Convert GraphQL FeedType (BREAST_MILK, FORMULA) to domain FeedType (breast_milk, formula)
+			// Convert GraphQL FeedType (BREAST_MILK, FORMULA, SOLIDS) to domain FeedType (breast_milk, formula, solids)
 			var feedType *domain.FeedType
 			if activityInput.FeedDetails.FeedType != nil {
 				ft := domain.FeedType(strings.ToLower(string(*activityInput.FeedDetails.FeedType)))
@@ -426,15 +426,25 @@ func (r *mutationResolver) AddActivities(ctx context.Context, activities []*mode
 				amountMl = &val
 			}
 
+			// Convert SolidsUnit to string for QuantityUnit
+			var quantityUnit *string
+			if activityInput.FeedDetails.QuantityUnit != nil {
+				qu := strings.ToLower(string(*activityInput.FeedDetails.QuantityUnit))
+				quantityUnit = &qu
+			}
+
 			details := &domain.FeedDetails{
-				ID:         uuid.New(),
-				ActivityID: activity.ID,
-				StartTime:  activityInput.FeedDetails.StartTime,
-				EndTime:    activityInput.FeedDetails.EndTime,
-				AmountMl:   amountMl,
-				FeedType:   feedType,
-				CreatedAt:  now,
-				UpdatedAt:  now,
+				ID:           uuid.New(),
+				ActivityID:   activity.ID,
+				StartTime:    activityInput.FeedDetails.StartTime,
+				EndTime:      activityInput.FeedDetails.EndTime,
+				AmountMl:     amountMl,
+				FeedType:     feedType,
+				FoodName:     activityInput.FeedDetails.FoodName,
+				Quantity:     activityInput.FeedDetails.Quantity,
+				QuantityUnit: quantityUnit,
+				CreatedAt:    now,
+				UpdatedAt:    now,
 			}
 			fmt.Printf("📝 Creating feed details for activity %s (feed_type: %v)\n", activity.ID, feedType)
 			if err := r.store.CreateFeedDetails(ctx, details); err != nil {
@@ -681,6 +691,16 @@ func (r *mutationResolver) UpdateActivity(ctx context.Context, activityID string
 			feedDetails.FeedType = nil
 		}
 
+		feedDetails.FoodName = input.FeedDetails.FoodName
+		feedDetails.Quantity = input.FeedDetails.Quantity
+
+		if input.FeedDetails.QuantityUnit != nil {
+			qu := strings.ToLower(string(*input.FeedDetails.QuantityUnit))
+			feedDetails.QuantityUnit = &qu
+		} else {
+			feedDetails.QuantityUnit = nil
+		}
+
 		feedDetails.UpdatedAt = now
 
 		if err := r.store.UpdateFeedDetails(ctx, feedDetails); err != nil {
@@ -886,4 +906,3 @@ func (r *Resolver) Query() QueryResolver { return &queryResolver{r} }
 
 type mutationResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
-

--- a/backend/internal/ai/claude_client.go
+++ b/backend/internal/ai/claude_client.go
@@ -133,15 +133,25 @@ Voice input: "%s"
 Rules:
 1. "now" or "right now" = current local time
 2. Relative times like "at 2:30" are absolute within today in the user's timezone
-3. Default feed type to "FORMULA" if not specified
+3. Default feed type to "FORMULA" if not specified (for liquid feeds)
 4. "pooped" means had_poop=true for diaper change
 5. "peed" means had_pee=true for diaper change
 6. ALL timestamps MUST use the user's timezone offset (e.g. -05:00), NEVER use "Z"
+7. If the caregiver mentions solid food (e.g. carrots, avocado, banana, rice cereal, puree), set feed_type to "SOLIDS". Extract food_name, quantity, and quantity_unit if mentioned.
 
-FEED ACTIVITIES:
+FEED ACTIVITIES (FORMULA/BREAST_MILK):
 - MUST have: start_time, amount_ml, feed_type
+- amount_ml should be set; food_name/quantity/quantity_unit should be null
 - If end_time provided: use it
 - If end_time NOT provided: set to null (will auto-calculate as start_time + 45 minutes)
+
+FEED ACTIVITIES (SOLIDS):
+- MUST have: start_time, feed_type ("SOLIDS"), food_name
+- quantity and quantity_unit are optional (use if mentioned)
+- quantity_unit must be one of: "SPOONS", "BOWLS", "PIECES", "PORTIONS"
+- amount_ml should be null for solids
+- If end_time provided: use it
+- If end_time NOT provided: set to null
 
 SLEEP ACTIVITIES:
 - MUST have: start_time
@@ -156,18 +166,39 @@ Extract all activities mentioned. Return ONLY valid JSON array (no markdown, no 
 
 [
   {
-    "activity_type": "FEED|DIAPER|SLEEP",
+    "activity_type": "FEED",
     "feed_details": {
       "start_time": "2024-01-15T14:30:00-05:00",
       "end_time": null,
       "amount_ml": 60,
-      "feed_type": "FORMULA"
-    },
+      "feed_type": "FORMULA",
+      "food_name": null,
+      "quantity": null,
+      "quantity_unit": null
+    }
+  },
+  {
+    "activity_type": "FEED",
+    "feed_details": {
+      "start_time": "2024-01-15T12:00:00-05:00",
+      "end_time": null,
+      "amount_ml": null,
+      "feed_type": "SOLIDS",
+      "food_name": "mushed carrots",
+      "quantity": 10,
+      "quantity_unit": "SPOONS"
+    }
+  },
+  {
+    "activity_type": "DIAPER",
     "diaper_details": {
       "changed_at": "2024-01-15T14:55:00-05:00",
       "had_poop": true,
       "had_pee": true
-    },
+    }
+  },
+  {
+    "activity_type": "SLEEP",
     "sleep_details": {
       "start_time": "2024-01-15T15:00:00-05:00",
       "end_time": null

--- a/backend/internal/ai/parser.go
+++ b/backend/internal/ai/parser.go
@@ -68,6 +68,19 @@ func parseFeedDetailsOutput(details map[string]interface{}) *model.FeedDetails {
 		fd.FeedType = &ft
 	}
 
+	if foodName, ok := details["food_name"].(string); ok {
+		fd.FoodName = &foodName
+	}
+
+	if quantity, ok := details["quantity"].(float64); ok {
+		fd.Quantity = &quantity
+	}
+
+	if quantityUnit, ok := details["quantity_unit"].(string); ok {
+		qu := model.SolidsUnit(quantityUnit)
+		fd.QuantityUnit = &qu
+	}
+
 	// Calculate duration if both times exist
 	if fd.EndTime != nil {
 		duration := int32(fd.EndTime.Sub(fd.StartTime).Minutes())
@@ -185,6 +198,19 @@ func parseFeedDetails(details map[string]interface{}) *model.FeedDetailsInput {
 	if feedType, ok := details["feed_type"].(string); ok {
 		ft := model.FeedType(feedType)
 		fd.FeedType = &ft
+	}
+
+	if foodName, ok := details["food_name"].(string); ok {
+		fd.FoodName = &foodName
+	}
+
+	if quantity, ok := details["quantity"].(float64); ok {
+		fd.Quantity = &quantity
+	}
+
+	if quantityUnit, ok := details["quantity_unit"].(string); ok {
+		qu := model.SolidsUnit(quantityUnit)
+		fd.QuantityUnit = &qu
 	}
 
 	return fd

--- a/backend/internal/ai/parser_test.go
+++ b/backend/internal/ai/parser_test.go
@@ -363,6 +363,220 @@ func TestConvertToActivityInputs_EmptyInput(t *testing.T) {
 	}
 }
 
+func TestConvertToParsedActivities_Solids(t *testing.T) {
+	activities := []map[string]interface{}{
+		{
+			"activity_type": "FEED",
+			"feed_details": map[string]interface{}{
+				"start_time":    "2024-01-01T12:00:00Z",
+				"feed_type":     "SOLIDS",
+				"food_name":     "mushed carrots",
+				"quantity":      float64(10),
+				"quantity_unit": "SPOONS",
+			},
+		},
+	}
+
+	result, errors := ConvertToParsedActivities(activities)
+
+	if len(errors) != 0 {
+		t.Fatalf("unexpected errors: %v", errors)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result))
+	}
+
+	r := result[0]
+	if r.ActivityType != model.ActivityTypeFeed {
+		t.Errorf("ActivityType = %q, want %q", r.ActivityType, model.ActivityTypeFeed)
+	}
+	if r.FeedDetails == nil {
+		t.Fatal("expected FeedDetails to be set")
+	}
+	if r.FeedDetails.FeedType == nil || *r.FeedDetails.FeedType != model.FeedTypeSolids {
+		t.Errorf("FeedType = %v, want SOLIDS", r.FeedDetails.FeedType)
+	}
+	if r.FeedDetails.FoodName == nil || *r.FeedDetails.FoodName != "mushed carrots" {
+		t.Errorf("FoodName = %v, want 'mushed carrots'", r.FeedDetails.FoodName)
+	}
+	if r.FeedDetails.Quantity == nil || *r.FeedDetails.Quantity != 10.0 {
+		t.Errorf("Quantity = %v, want 10", r.FeedDetails.Quantity)
+	}
+	if r.FeedDetails.QuantityUnit == nil || *r.FeedDetails.QuantityUnit != model.SolidsUnitSpoons {
+		t.Errorf("QuantityUnit = %v, want SPOONS", r.FeedDetails.QuantityUnit)
+	}
+	if r.FeedDetails.AmountMl != nil {
+		t.Errorf("AmountMl = %v, want nil for solids", r.FeedDetails.AmountMl)
+	}
+}
+
+func TestConvertToParsedActivities_Solids_NoQuantity(t *testing.T) {
+	activities := []map[string]interface{}{
+		{
+			"activity_type": "FEED",
+			"feed_details": map[string]interface{}{
+				"start_time": "2024-01-01T12:00:00Z",
+				"feed_type":  "SOLIDS",
+				"food_name":  "banana",
+			},
+		},
+	}
+
+	result, errors := ConvertToParsedActivities(activities)
+
+	if len(errors) != 0 {
+		t.Fatalf("unexpected errors: %v", errors)
+	}
+
+	r := result[0]
+	if r.FeedDetails.FoodName == nil || *r.FeedDetails.FoodName != "banana" {
+		t.Errorf("FoodName = %v, want 'banana'", r.FeedDetails.FoodName)
+	}
+	if r.FeedDetails.Quantity != nil {
+		t.Errorf("Quantity = %v, want nil", r.FeedDetails.Quantity)
+	}
+	if r.FeedDetails.QuantityUnit != nil {
+		t.Errorf("QuantityUnit = %v, want nil", r.FeedDetails.QuantityUnit)
+	}
+}
+
+func TestConvertToParsedActivities_Formula_Unchanged(t *testing.T) {
+	activities := []map[string]interface{}{
+		{
+			"activity_type": "FEED",
+			"feed_details": map[string]interface{}{
+				"start_time": "2024-01-01T10:00:00Z",
+				"amount_ml":  float64(120),
+				"feed_type":  "FORMULA",
+			},
+		},
+	}
+
+	result, errors := ConvertToParsedActivities(activities)
+
+	if len(errors) != 0 {
+		t.Fatalf("unexpected errors: %v", errors)
+	}
+
+	r := result[0]
+	if r.FeedDetails.FeedType == nil || *r.FeedDetails.FeedType != model.FeedTypeFormula {
+		t.Errorf("FeedType = %v, want FORMULA", r.FeedDetails.FeedType)
+	}
+	if r.FeedDetails.AmountMl == nil || *r.FeedDetails.AmountMl != 120 {
+		t.Errorf("AmountMl = %v, want 120", r.FeedDetails.AmountMl)
+	}
+	if r.FeedDetails.FoodName != nil {
+		t.Errorf("FoodName = %v, want nil for formula", r.FeedDetails.FoodName)
+	}
+	if r.FeedDetails.Quantity != nil {
+		t.Errorf("Quantity = %v, want nil for formula", r.FeedDetails.Quantity)
+	}
+	if r.FeedDetails.QuantityUnit != nil {
+		t.Errorf("QuantityUnit = %v, want nil for formula", r.FeedDetails.QuantityUnit)
+	}
+}
+
+func TestConvertToActivityInputs_Solids(t *testing.T) {
+	activities := []map[string]interface{}{
+		{
+			"activity_type": "FEED",
+			"feed_details": map[string]interface{}{
+				"start_time":    "2024-01-01T12:00:00Z",
+				"feed_type":     "SOLIDS",
+				"food_name":     "mushed carrots",
+				"quantity":      float64(10),
+				"quantity_unit": "SPOONS",
+			},
+		},
+	}
+
+	result, errors := ConvertToActivityInputs(activities)
+
+	if len(errors) != 0 {
+		t.Fatalf("unexpected errors: %v", errors)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result))
+	}
+
+	r := result[0]
+	if r.FeedDetails == nil {
+		t.Fatal("expected FeedDetails to be set")
+	}
+	if r.FeedDetails.FeedType == nil || *r.FeedDetails.FeedType != model.FeedTypeSolids {
+		t.Errorf("FeedType = %v, want SOLIDS", r.FeedDetails.FeedType)
+	}
+	if r.FeedDetails.FoodName == nil || *r.FeedDetails.FoodName != "mushed carrots" {
+		t.Errorf("FoodName = %v, want 'mushed carrots'", r.FeedDetails.FoodName)
+	}
+	if r.FeedDetails.Quantity == nil || *r.FeedDetails.Quantity != 10.0 {
+		t.Errorf("Quantity = %v, want 10", r.FeedDetails.Quantity)
+	}
+	if r.FeedDetails.QuantityUnit == nil || *r.FeedDetails.QuantityUnit != model.SolidsUnitSpoons {
+		t.Errorf("QuantityUnit = %v, want SPOONS", r.FeedDetails.QuantityUnit)
+	}
+}
+
+func TestConvertToActivityInputs_Solids_NoQuantity(t *testing.T) {
+	activities := []map[string]interface{}{
+		{
+			"activity_type": "FEED",
+			"feed_details": map[string]interface{}{
+				"start_time": "2024-01-01T12:00:00Z",
+				"feed_type":  "SOLIDS",
+				"food_name":  "banana",
+			},
+		},
+	}
+
+	result, errors := ConvertToActivityInputs(activities)
+
+	if len(errors) != 0 {
+		t.Fatalf("unexpected errors: %v", errors)
+	}
+
+	r := result[0]
+	if r.FeedDetails.FoodName == nil || *r.FeedDetails.FoodName != "banana" {
+		t.Errorf("FoodName = %v, want 'banana'", r.FeedDetails.FoodName)
+	}
+	if r.FeedDetails.Quantity != nil {
+		t.Errorf("Quantity = %v, want nil", r.FeedDetails.Quantity)
+	}
+	if r.FeedDetails.QuantityUnit != nil {
+		t.Errorf("QuantityUnit = %v, want nil", r.FeedDetails.QuantityUnit)
+	}
+}
+
+func TestConvertToActivityInputs_Formula_Unchanged(t *testing.T) {
+	activities := []map[string]interface{}{
+		{
+			"activity_type": "FEED",
+			"feed_details": map[string]interface{}{
+				"start_time": "2024-01-01T10:00:00Z",
+				"amount_ml":  float64(120),
+				"feed_type":  "FORMULA",
+			},
+		},
+	}
+
+	result, errors := ConvertToActivityInputs(activities)
+
+	if len(errors) != 0 {
+		t.Fatalf("unexpected errors: %v", errors)
+	}
+
+	r := result[0]
+	if r.FeedDetails.FeedType == nil || *r.FeedDetails.FeedType != model.FeedTypeFormula {
+		t.Errorf("FeedType = %v, want FORMULA", r.FeedDetails.FeedType)
+	}
+	if r.FeedDetails.AmountMl == nil || *r.FeedDetails.AmountMl != 120 {
+		t.Errorf("AmountMl = %v, want 120", r.FeedDetails.AmountMl)
+	}
+	if r.FeedDetails.FoodName != nil {
+		t.Errorf("FoodName = %v, want nil for formula", r.FeedDetails.FoodName)
+	}
+}
+
 func TestConvertToActivityInputs_FeedNoEndTime(t *testing.T) {
 	activities := []map[string]interface{}{
 		{

--- a/backend/internal/mapper/to_graphql.go
+++ b/backend/internal/mapper/to_graphql.go
@@ -1,6 +1,8 @@
 package mapper
 
 import (
+	"strings"
+
 	"github.com/swatkatz/babybaton/backend/graph/model"
 	"github.com/swatkatz/babybaton/backend/internal/domain"
 )
@@ -112,12 +114,21 @@ func FeedDetailsToGraphQL(fd *domain.FeedDetails) *model.FeedDetails {
 		amountMl = &amt
 	}
 
+	var quantityUnit *model.SolidsUnit
+	if fd.QuantityUnit != nil {
+		qu := model.SolidsUnit(strings.ToUpper(*fd.QuantityUnit))
+		quantityUnit = &qu
+	}
+
 	return &model.FeedDetails{
 		StartTime:       fd.StartTime,
 		EndTime:         fd.EndTime,
 		AmountMl:        amountMl,
 		FeedType:        feedType,
 		DurationMinutes: durationMinutes, // Calculated field
+		FoodName:        fd.FoodName,
+		Quantity:        fd.Quantity,
+		QuantityUnit:    quantityUnit,
 	}
 }
 

--- a/backend/internal/store/postgres/activity_details_test.go
+++ b/backend/internal/store/postgres/activity_details_test.go
@@ -277,4 +277,166 @@ func TestActivityDetailsOperations(t *testing.T) {
 		}
 		t.Logf("✓ Updated sleep start_time: %d minutes", *updatedAgain.DurationMinutes)
 	})
+
+	// Test Solids Feed Details
+	t.Run("CreateFeedDetails_Solids", func(t *testing.T) {
+		solidsActivity := &domain.Activity{
+			ID:            uuid.New(),
+			CareSessionID: session.ID,
+			ActivityType:  domain.ActivityTypeFeed,
+			CreatedAt:     time.Now(),
+			UpdatedAt:     time.Now(),
+		}
+		if err := store.CreateActivity(ctx, solidsActivity); err != nil {
+			t.Fatalf("Failed to create solids activity: %v", err)
+		}
+
+		startTime := time.Now()
+		feedType := domain.FeedTypeSolids
+		foodName := "mushed carrots"
+		quantity := 10.0
+		quantityUnit := "spoons"
+
+		solidsDetails := &domain.FeedDetails{
+			ID:           uuid.New(),
+			ActivityID:   solidsActivity.ID,
+			StartTime:    startTime,
+			FeedType:     &feedType,
+			FoodName:     &foodName,
+			Quantity:     &quantity,
+			QuantityUnit: &quantityUnit,
+			CreatedAt:    time.Now(),
+			UpdatedAt:    time.Now(),
+		}
+
+		err := store.CreateFeedDetails(ctx, solidsDetails)
+		if err != nil {
+			t.Fatalf("Failed to create solids feed details: %v", err)
+		}
+
+		retrieved, err := store.GetFeedDetails(ctx, solidsActivity.ID)
+		if err != nil {
+			t.Fatalf("Failed to get solids feed details: %v", err)
+		}
+		if retrieved.FeedType == nil || *retrieved.FeedType != domain.FeedTypeSolids {
+			t.Errorf("Expected feed type solids, got %v", retrieved.FeedType)
+		}
+		if retrieved.FoodName == nil || *retrieved.FoodName != "mushed carrots" {
+			t.Errorf("Expected food name 'mushed carrots', got %v", retrieved.FoodName)
+		}
+		if retrieved.Quantity == nil || *retrieved.Quantity != 10.0 {
+			t.Errorf("Expected quantity 10, got %v", retrieved.Quantity)
+		}
+		if retrieved.QuantityUnit == nil || *retrieved.QuantityUnit != "spoons" {
+			t.Errorf("Expected quantity unit 'spoons', got %v", retrieved.QuantityUnit)
+		}
+		if retrieved.AmountMl != nil {
+			t.Errorf("Expected amount_ml to be nil for solids, got %v", retrieved.AmountMl)
+		}
+		t.Logf("✓ Created and retrieved solids feed: %s (%v %s)", *retrieved.FoodName, *retrieved.Quantity, *retrieved.QuantityUnit)
+	})
+
+	// Test Solids Feed Details with minimal fields (food name only)
+	t.Run("CreateFeedDetails_Solids_MinimalFields", func(t *testing.T) {
+		minimalActivity := &domain.Activity{
+			ID:            uuid.New(),
+			CareSessionID: session.ID,
+			ActivityType:  domain.ActivityTypeFeed,
+			CreatedAt:     time.Now(),
+			UpdatedAt:     time.Now(),
+		}
+		if err := store.CreateActivity(ctx, minimalActivity); err != nil {
+			t.Fatalf("Failed to create minimal solids activity: %v", err)
+		}
+
+		startTime := time.Now()
+		feedType := domain.FeedTypeSolids
+		foodName := "avocado"
+
+		minimalDetails := &domain.FeedDetails{
+			ID:         uuid.New(),
+			ActivityID: minimalActivity.ID,
+			StartTime:  startTime,
+			FeedType:   &feedType,
+			FoodName:   &foodName,
+			CreatedAt:  time.Now(),
+			UpdatedAt:  time.Now(),
+		}
+
+		err := store.CreateFeedDetails(ctx, minimalDetails)
+		if err != nil {
+			t.Fatalf("Failed to create minimal solids feed details: %v", err)
+		}
+
+		retrieved, err := store.GetFeedDetails(ctx, minimalActivity.ID)
+		if err != nil {
+			t.Fatalf("Failed to get minimal solids feed details: %v", err)
+		}
+		if retrieved.FoodName == nil || *retrieved.FoodName != "avocado" {
+			t.Errorf("Expected food name 'avocado', got %v", retrieved.FoodName)
+		}
+		if retrieved.Quantity != nil {
+			t.Errorf("Expected quantity to be nil, got %v", retrieved.Quantity)
+		}
+		if retrieved.QuantityUnit != nil {
+			t.Errorf("Expected quantity unit to be nil, got %v", retrieved.QuantityUnit)
+		}
+		t.Logf("✓ Created and retrieved minimal solids feed: %s (no quantity)", *retrieved.FoodName)
+	})
+
+	// Regression: Formula feed still works unchanged
+	t.Run("CreateFeedDetails_Formula_Unchanged", func(t *testing.T) {
+		formulaActivity := &domain.Activity{
+			ID:            uuid.New(),
+			CareSessionID: session.ID,
+			ActivityType:  domain.ActivityTypeFeed,
+			CreatedAt:     time.Now(),
+			UpdatedAt:     time.Now(),
+		}
+		if err := store.CreateActivity(ctx, formulaActivity); err != nil {
+			t.Fatalf("Failed to create formula activity: %v", err)
+		}
+
+		startTime := time.Now()
+		endTime := startTime.Add(15 * time.Minute)
+		amountMl := 150
+		feedType := domain.FeedTypeFormula
+
+		formulaDetails := &domain.FeedDetails{
+			ID:         uuid.New(),
+			ActivityID: formulaActivity.ID,
+			StartTime:  startTime,
+			EndTime:    &endTime,
+			AmountMl:   &amountMl,
+			FeedType:   &feedType,
+			CreatedAt:  time.Now(),
+			UpdatedAt:  time.Now(),
+		}
+
+		err := store.CreateFeedDetails(ctx, formulaDetails)
+		if err != nil {
+			t.Fatalf("Failed to create formula feed details: %v", err)
+		}
+
+		retrieved, err := store.GetFeedDetails(ctx, formulaActivity.ID)
+		if err != nil {
+			t.Fatalf("Failed to get formula feed details: %v", err)
+		}
+		if retrieved.FeedType == nil || *retrieved.FeedType != domain.FeedTypeFormula {
+			t.Errorf("Expected feed type formula, got %v", retrieved.FeedType)
+		}
+		if retrieved.AmountMl == nil || *retrieved.AmountMl != 150 {
+			t.Errorf("Expected amount 150ml, got %v", retrieved.AmountMl)
+		}
+		if retrieved.FoodName != nil {
+			t.Errorf("Expected food name to be nil for formula, got %v", retrieved.FoodName)
+		}
+		if retrieved.Quantity != nil {
+			t.Errorf("Expected quantity to be nil for formula, got %v", retrieved.Quantity)
+		}
+		if retrieved.QuantityUnit != nil {
+			t.Errorf("Expected quantity unit to be nil for formula, got %v", retrieved.QuantityUnit)
+		}
+		t.Logf("✓ Formula feed unchanged: %dml %s", *retrieved.AmountMl, *retrieved.FeedType)
+	})
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -16,6 +16,14 @@ enum ActivityType {
 enum FeedType {
   BREAST_MILK
   FORMULA
+  SOLIDS
+}
+
+enum SolidsUnit {
+  SPOONS
+  BOWLS
+  PIECES
+  PORTIONS
 }
 
 enum PredictionConfidence {
@@ -73,6 +81,9 @@ type FeedDetails {
   amountMl: Int
   feedType: FeedType
   durationMinutes: Int
+  foodName: String
+  quantity: Float
+  quantityUnit: SolidsUnit
 }
 
 type DiaperDetails {
@@ -151,6 +162,9 @@ input FeedDetailsInput {
   endTime: DateTime
   amountMl: Int
   feedType: FeedType
+  foodName: String
+  quantity: Float
+  quantityUnit: SolidsUnit
 }
 
 input DiaperDetailsInput {


### PR DESCRIPTION
## Summary

Closes #34

- Add solids tracking to feed activity: backend (#34)

## Test plan

- [ ] Verify the changes address the issue requirements
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)