### PR TITLE
Fix #24: Backend auth middleware: dual auth support

### DIFF
--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -3,9 +3,14 @@ package middleware
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
+	"strings"
 
 	"github.com/google/uuid"
+	"github.com/swatkatz/babybaton/backend/internal/auth"
+	"github.com/swatkatz/babybaton/backend/internal/domain"
+	"github.com/swatkatz/babybaton/backend/internal/store"
 )
 
 type contextKey string
@@ -14,9 +19,12 @@ const (
 	CaregiverIDKey contextKey = "caregiverId"
 	FamilyIDKey    contextKey = "familyId"
 	TimezoneKey    contextKey = "timezone"
+	UserIDKey      contextKey = "userId"
+	UserKey        contextKey = "user"
 )
 
-// AuthMiddleware extracts caregiver and family IDs from headers
+// AuthMiddleware extracts caregiver and family IDs from headers (legacy device-based auth).
+// Use NewDualAuthMiddleware for combined JWT + header auth support.
 func AuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
@@ -51,6 +59,123 @@ func AuthMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// DualAuthMiddleware supports both JWT Bearer token auth and legacy header-based auth.
+type DualAuthMiddleware struct {
+	verifier auth.AuthVerifier
+	store    store.Store
+}
+
+// NewDualAuthMiddleware creates middleware that checks auth in order:
+// 1. Authorization: Bearer <jwt> → verify via AuthVerifier, resolve user → caregiver + family
+// 2. X-Family-ID + X-Caregiver-ID headers → existing device-based path
+// 3. Neither → unauthenticated (passes through with no auth context)
+func NewDualAuthMiddleware(verifier auth.AuthVerifier, store store.Store) *DualAuthMiddleware {
+	return &DualAuthMiddleware{
+		verifier: verifier,
+		store:    store,
+	}
+}
+
+// Handler returns the HTTP middleware handler.
+func (m *DualAuthMiddleware) Handler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		token := extractBearerToken(r)
+		if token != "" {
+			// JWT auth path
+			ctx = m.handleJWTAuth(ctx, w, r, token)
+			if ctx == nil {
+				// handleJWTAuth already wrote the error response
+				return
+			}
+		} else {
+			// Legacy header-based auth path
+			ctx = handleHeaderAuth(ctx, r)
+		}
+
+		// Always extract timezone
+		timezone := r.Header.Get("X-Timezone")
+		if timezone == "" {
+			timezone = "UTC"
+		}
+		ctx = context.WithValue(ctx, TimezoneKey, timezone)
+
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// handleJWTAuth verifies the JWT, looks up the user, and resolves the caregiver
+// if X-Family-Id is also provided. Returns nil context if verification fails
+// (and writes the HTTP error response).
+func (m *DualAuthMiddleware) handleJWTAuth(ctx context.Context, w http.ResponseWriter, r *http.Request, token string) context.Context {
+	supabaseID, _, err := m.verifier.VerifyToken(ctx, token)
+	if err != nil {
+		log.Printf("JWT verification failed: %v", err)
+		http.Error(w, "invalid or expired token", http.StatusUnauthorized)
+		return nil
+	}
+
+	user, err := m.store.GetUserBySupabaseID(ctx, supabaseID)
+	if err != nil {
+		log.Printf("User lookup failed for supabase ID %s: %v", supabaseID, err)
+		http.Error(w, "user not found", http.StatusUnauthorized)
+		return nil
+	}
+
+	ctx = context.WithValue(ctx, UserIDKey, user.ID)
+	ctx = context.WithValue(ctx, UserKey, user)
+
+	// If X-Family-Id is provided, resolve the specific caregiver for this user+family
+	familyIDStr := r.Header.Get("X-Family-Id")
+	if familyIDStr != "" {
+		familyID, err := uuid.Parse(familyIDStr)
+		if err == nil {
+			caregiver, err := m.store.GetCaregiverByUserAndFamily(ctx, user.ID, familyID)
+			if err == nil {
+				ctx = context.WithValue(ctx, CaregiverIDKey, caregiver.ID)
+				ctx = context.WithValue(ctx, FamilyIDKey, familyID)
+			}
+		}
+	}
+
+	return ctx
+}
+
+// handleHeaderAuth extracts caregiver and family IDs from legacy headers.
+func handleHeaderAuth(ctx context.Context, r *http.Request) context.Context {
+	caregiverIDStr := r.Header.Get("X-Caregiver-Id")
+	if caregiverIDStr != "" {
+		caregiverID, err := uuid.Parse(caregiverIDStr)
+		if err == nil {
+			ctx = context.WithValue(ctx, CaregiverIDKey, caregiverID)
+		}
+	}
+
+	familyIDStr := r.Header.Get("X-Family-Id")
+	if familyIDStr != "" {
+		familyID, err := uuid.Parse(familyIDStr)
+		if err == nil {
+			ctx = context.WithValue(ctx, FamilyIDKey, familyID)
+		}
+	}
+
+	return ctx
+}
+
+// extractBearerToken extracts the token from an "Authorization: Bearer <token>" header.
+func extractBearerToken(r *http.Request) string {
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		return ""
+	}
+	parts := strings.SplitN(authHeader, " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		return ""
+	}
+	return strings.TrimSpace(parts[1])
+}
+
 // GetCaregiverID extracts caregiver ID from context
 func GetCaregiverID(ctx context.Context) (uuid.UUID, bool) {
 	caregiverID, ok := ctx.Value(CaregiverIDKey).(uuid.UUID)
@@ -69,6 +194,18 @@ func GetTimezone(ctx context.Context) string {
 		return tz
 	}
 	return "UTC" // Default fallback
+}
+
+// GetUserID extracts user ID from context (set by JWT auth path)
+func GetUserID(ctx context.Context) (uuid.UUID, bool) {
+	userID, ok := ctx.Value(UserIDKey).(uuid.UUID)
+	return userID, ok
+}
+
+// GetUser extracts user from context (set by JWT auth path)
+func GetUser(ctx context.Context) (*domain.User, bool) {
+	user, ok := ctx.Value(UserKey).(*domain.User)
+	return user, ok
 }
 
 // RequireAuth returns error if caregiver/family not in context

--- a/backend/internal/middleware/auth_test.go
+++ b/backend/internal/middleware/auth_test.go
@@ -2,12 +2,141 @@ package middleware
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/swatkatz/babybaton/backend/internal/domain"
 )
+
+// --- Mock AuthVerifier ---
+
+type mockVerifier struct {
+	userID string
+	email  string
+	err    error
+}
+
+func (m *mockVerifier) VerifyToken(ctx context.Context, token string) (string, string, error) {
+	return m.userID, m.email, m.err
+}
+
+// --- Mock Store (only methods needed by middleware) ---
+
+type mockStore struct {
+	user      *domain.User
+	userErr   error
+	caregiver *domain.Caregiver
+	cgErr     error
+}
+
+func (m *mockStore) GetUserBySupabaseID(ctx context.Context, supabaseUserID string) (*domain.User, error) {
+	return m.user, m.userErr
+}
+
+func (m *mockStore) GetCaregiverByUserAndFamily(ctx context.Context, userID uuid.UUID, familyID uuid.UUID) (*domain.Caregiver, error) {
+	return m.caregiver, m.cgErr
+}
+
+// Stub out remaining Store interface methods (not used by middleware)
+func (m *mockStore) CreateFamilyWithCaregiver(ctx context.Context, family *domain.Family, caregiver *domain.Caregiver) error {
+	return nil
+}
+func (m *mockStore) GetFamilyByID(ctx context.Context, id uuid.UUID) (*domain.Family, error) {
+	return nil, nil
+}
+func (m *mockStore) GetFamilyByName(ctx context.Context, name string) (*domain.Family, error) {
+	return nil, nil
+}
+func (m *mockStore) UpdateFamily(ctx context.Context, family *domain.Family) error { return nil }
+func (m *mockStore) DeleteFamily(ctx context.Context, id uuid.UUID) error          { return nil }
+func (m *mockStore) FamilyNameExists(ctx context.Context, name string) (bool, error) {
+	return false, nil
+}
+func (m *mockStore) CreateUser(ctx context.Context, user *domain.User) error { return nil }
+func (m *mockStore) GetUserByID(ctx context.Context, id uuid.UUID) (*domain.User, error) {
+	return nil, nil
+}
+func (m *mockStore) CreateCaregiver(ctx context.Context, caregiver *domain.Caregiver) error {
+	return nil
+}
+func (m *mockStore) GetCaregiverByID(ctx context.Context, id uuid.UUID) (*domain.Caregiver, error) {
+	return nil, nil
+}
+func (m *mockStore) GetCaregiverByDeviceID(ctx context.Context, deviceID string) (*domain.Caregiver, error) {
+	return nil, nil
+}
+func (m *mockStore) GetCaregiversByFamily(ctx context.Context, familyID uuid.UUID) ([]*domain.Caregiver, error) {
+	return nil, nil
+}
+func (m *mockStore) UpdateCaregiver(ctx context.Context, caregiver *domain.Caregiver) error {
+	return nil
+}
+func (m *mockStore) LinkCaregiverToUser(ctx context.Context, caregiverID uuid.UUID, userID uuid.UUID) error {
+	return nil
+}
+func (m *mockStore) DeleteCaregiver(ctx context.Context, id uuid.UUID) error { return nil }
+func (m *mockStore) CreateCareSession(ctx context.Context, session *domain.CareSession) error {
+	return nil
+}
+func (m *mockStore) GetCareSessionByID(ctx context.Context, id uuid.UUID) (*domain.CareSession, error) {
+	return nil, nil
+}
+func (m *mockStore) GetInProgressSessionForFamily(ctx context.Context, familyID uuid.UUID) (*domain.CareSession, error) {
+	return nil, nil
+}
+func (m *mockStore) GetRecentCareSessionsForFamily(ctx context.Context, familyID uuid.UUID, limit int) ([]*domain.CareSession, error) {
+	return nil, nil
+}
+func (m *mockStore) UpdateCareSession(ctx context.Context, session *domain.CareSession) error {
+	return nil
+}
+func (m *mockStore) DeleteCareSession(ctx context.Context, id uuid.UUID) error { return nil }
+func (m *mockStore) CreateActivity(ctx context.Context, activity *domain.Activity) error {
+	return nil
+}
+func (m *mockStore) GetActivityByID(ctx context.Context, id uuid.UUID) (*domain.Activity, error) {
+	return nil, nil
+}
+func (m *mockStore) GetActivitiesForSession(ctx context.Context, sessionID uuid.UUID) ([]*domain.Activity, error) {
+	return nil, nil
+}
+func (m *mockStore) DeleteActivity(ctx context.Context, id uuid.UUID) error { return nil }
+func (m *mockStore) CreateFeedDetails(ctx context.Context, details *domain.FeedDetails) error {
+	return nil
+}
+func (m *mockStore) GetFeedDetails(ctx context.Context, activityID uuid.UUID) (*domain.FeedDetails, error) {
+	return nil, nil
+}
+func (m *mockStore) GetRecentFeedDetailsForFamily(ctx context.Context, familyID uuid.UUID, limit int) ([]*domain.FeedDetails, error) {
+	return nil, nil
+}
+func (m *mockStore) UpdateFeedDetails(ctx context.Context, details *domain.FeedDetails) error {
+	return nil
+}
+func (m *mockStore) CreateDiaperDetails(ctx context.Context, details *domain.DiaperDetails) error {
+	return nil
+}
+func (m *mockStore) GetDiaperDetails(ctx context.Context, activityID uuid.UUID) (*domain.DiaperDetails, error) {
+	return nil, nil
+}
+func (m *mockStore) UpdateDiaperDetails(ctx context.Context, details *domain.DiaperDetails) error {
+	return nil
+}
+func (m *mockStore) CreateSleepDetails(ctx context.Context, details *domain.SleepDetails) error {
+	return nil
+}
+func (m *mockStore) GetSleepDetails(ctx context.Context, activityID uuid.UUID) (*domain.SleepDetails, error) {
+	return nil, nil
+}
+func (m *mockStore) UpdateSleepDetails(ctx context.Context, details *domain.SleepDetails) error {
+	return nil
+}
+func (m *mockStore) Close() error { return nil }
+
+// ==================== Legacy AuthMiddleware Tests ====================
 
 func TestAuthMiddleware_ParsesAllHeaders(t *testing.T) {
 	caregiverID := uuid.New()
@@ -166,5 +295,364 @@ func TestGetTimezone_FallbackForEmptyContext(t *testing.T) {
 	tz := GetTimezone(ctx)
 	if tz != "UTC" {
 		t.Errorf("timezone = %q, want %q", tz, "UTC")
+	}
+}
+
+// ==================== DualAuthMiddleware Tests ====================
+
+func newTestDualAuth(verifier *mockVerifier, store *mockStore) *DualAuthMiddleware {
+	return NewDualAuthMiddleware(verifier, store)
+}
+
+func TestDualAuth_ValidJWT_ResolvesUserAndCaregiver(t *testing.T) {
+	userID := uuid.New()
+	caregiverID := uuid.New()
+	familyID := uuid.New()
+
+	user := &domain.User{ID: userID, SupabaseUserID: "sup-123", Email: "test@example.com"}
+	caregiver := &domain.Caregiver{ID: caregiverID, FamilyID: familyID, UserID: &userID}
+
+	m := newTestDualAuth(
+		&mockVerifier{userID: "sup-123", email: "test@example.com"},
+		&mockStore{user: user, caregiver: caregiver},
+	)
+
+	var capturedCtx context.Context
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedCtx = r.Context()
+	})
+
+	req := httptest.NewRequest("POST", "/query", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	req.Header.Set("X-Family-Id", familyID.String())
+	req.Header.Set("X-Timezone", "America/Chicago")
+
+	rr := httptest.NewRecorder()
+	m.Handler(inner).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	// User context should be set
+	gotUserID, ok := GetUserID(capturedCtx)
+	if !ok {
+		t.Fatal("expected user ID in context")
+	}
+	if gotUserID != userID {
+		t.Errorf("user ID = %v, want %v", gotUserID, userID)
+	}
+
+	gotUser, ok := GetUser(capturedCtx)
+	if !ok {
+		t.Fatal("expected user in context")
+	}
+	if gotUser.Email != "test@example.com" {
+		t.Errorf("user email = %q, want %q", gotUser.Email, "test@example.com")
+	}
+
+	// Caregiver/family should be resolved
+	gotCaregiverID, ok := GetCaregiverID(capturedCtx)
+	if !ok {
+		t.Fatal("expected caregiver ID in context")
+	}
+	if gotCaregiverID != caregiverID {
+		t.Errorf("caregiver ID = %v, want %v", gotCaregiverID, caregiverID)
+	}
+
+	gotFamilyID, ok := GetFamilyID(capturedCtx)
+	if !ok {
+		t.Fatal("expected family ID in context")
+	}
+	if gotFamilyID != familyID {
+		t.Errorf("family ID = %v, want %v", gotFamilyID, familyID)
+	}
+
+	// Timezone
+	gotTz := GetTimezone(capturedCtx)
+	if gotTz != "America/Chicago" {
+		t.Errorf("timezone = %q, want %q", gotTz, "America/Chicago")
+	}
+}
+
+func TestDualAuth_ValidJWT_WithoutFamilyID(t *testing.T) {
+	userID := uuid.New()
+	user := &domain.User{ID: userID, SupabaseUserID: "sup-123", Email: "test@example.com"}
+
+	m := newTestDualAuth(
+		&mockVerifier{userID: "sup-123", email: "test@example.com"},
+		&mockStore{user: user},
+	)
+
+	var capturedCtx context.Context
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedCtx = r.Context()
+	})
+
+	req := httptest.NewRequest("POST", "/query", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+
+	rr := httptest.NewRecorder()
+	m.Handler(inner).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	// User context should be set
+	_, ok := GetUserID(capturedCtx)
+	if !ok {
+		t.Fatal("expected user ID in context")
+	}
+
+	// No caregiver/family without X-Family-Id
+	_, ok = GetCaregiverID(capturedCtx)
+	if ok {
+		t.Error("expected no caregiver ID without X-Family-Id header")
+	}
+
+	_, ok = GetFamilyID(capturedCtx)
+	if ok {
+		t.Error("expected no family ID without X-Family-Id header")
+	}
+}
+
+func TestDualAuth_ExpiredJWT_Returns401(t *testing.T) {
+	m := newTestDualAuth(
+		&mockVerifier{err: fmt.Errorf("token expired")},
+		&mockStore{},
+	)
+
+	handlerCalled := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+	})
+
+	req := httptest.NewRequest("POST", "/query", nil)
+	req.Header.Set("Authorization", "Bearer expired-token")
+
+	rr := httptest.NewRecorder()
+	m.Handler(inner).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", rr.Code)
+	}
+	if handlerCalled {
+		t.Error("handler should not be called on JWT failure")
+	}
+}
+
+func TestDualAuth_InvalidJWT_Returns401(t *testing.T) {
+	m := newTestDualAuth(
+		&mockVerifier{err: fmt.Errorf("invalid token")},
+		&mockStore{},
+	)
+
+	handlerCalled := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+	})
+
+	req := httptest.NewRequest("POST", "/query", nil)
+	req.Header.Set("Authorization", "Bearer bad-token")
+
+	rr := httptest.NewRecorder()
+	m.Handler(inner).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", rr.Code)
+	}
+	if handlerCalled {
+		t.Error("handler should not be called on JWT failure")
+	}
+}
+
+func TestDualAuth_ValidJWT_UserNotFound_Returns401(t *testing.T) {
+	m := newTestDualAuth(
+		&mockVerifier{userID: "sup-unknown", email: "test@example.com"},
+		&mockStore{userErr: fmt.Errorf("user not found")},
+	)
+
+	handlerCalled := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+	})
+
+	req := httptest.NewRequest("POST", "/query", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+
+	rr := httptest.NewRecorder()
+	m.Handler(inner).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", rr.Code)
+	}
+	if handlerCalled {
+		t.Error("handler should not be called when user not found")
+	}
+}
+
+func TestDualAuth_FallsBackToHeaders_WhenNoBearer(t *testing.T) {
+	caregiverID := uuid.New()
+	familyID := uuid.New()
+
+	m := newTestDualAuth(
+		&mockVerifier{},
+		&mockStore{},
+	)
+
+	var capturedCtx context.Context
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedCtx = r.Context()
+	})
+
+	req := httptest.NewRequest("POST", "/query", nil)
+	req.Header.Set("X-Caregiver-Id", caregiverID.String())
+	req.Header.Set("X-Family-Id", familyID.String())
+	req.Header.Set("X-Timezone", "Europe/London")
+
+	rr := httptest.NewRecorder()
+	m.Handler(inner).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	gotCaregiverID, ok := GetCaregiverID(capturedCtx)
+	if !ok {
+		t.Fatal("expected caregiver ID in context")
+	}
+	if gotCaregiverID != caregiverID {
+		t.Errorf("caregiver ID = %v, want %v", gotCaregiverID, caregiverID)
+	}
+
+	gotFamilyID, ok := GetFamilyID(capturedCtx)
+	if !ok {
+		t.Fatal("expected family ID in context")
+	}
+	if gotFamilyID != familyID {
+		t.Errorf("family ID = %v, want %v", gotFamilyID, familyID)
+	}
+
+	// No user context on header-based auth
+	_, ok = GetUserID(capturedCtx)
+	if ok {
+		t.Error("expected no user ID on header-based auth")
+	}
+
+	gotTz := GetTimezone(capturedCtx)
+	if gotTz != "Europe/London" {
+		t.Errorf("timezone = %q, want %q", gotTz, "Europe/London")
+	}
+}
+
+func TestDualAuth_NoAuth_PassesThrough(t *testing.T) {
+	m := newTestDualAuth(
+		&mockVerifier{},
+		&mockStore{},
+	)
+
+	var capturedCtx context.Context
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedCtx = r.Context()
+	})
+
+	req := httptest.NewRequest("POST", "/query", nil)
+	rr := httptest.NewRecorder()
+	m.Handler(inner).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	_, ok := GetCaregiverID(capturedCtx)
+	if ok {
+		t.Error("expected no caregiver ID")
+	}
+	_, ok = GetFamilyID(capturedCtx)
+	if ok {
+		t.Error("expected no family ID")
+	}
+	_, ok = GetUserID(capturedCtx)
+	if ok {
+		t.Error("expected no user ID")
+	}
+
+	gotTz := GetTimezone(capturedCtx)
+	if gotTz != "UTC" {
+		t.Errorf("timezone = %q, want %q", gotTz, "UTC")
+	}
+}
+
+// ==================== extractBearerToken Tests ====================
+
+func TestExtractBearerToken(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{"valid bearer", "Bearer my-token", "my-token"},
+		{"case insensitive", "bearer my-token", "my-token"},
+		{"BEARER uppercase", "BEARER my-token", "my-token"},
+		{"empty header", "", ""},
+		{"no bearer prefix", "Basic abc123", ""},
+		{"bearer only no token", "Bearer ", ""},
+		{"token with spaces trimmed", "Bearer  my-token ", "my-token"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "/query", nil)
+			if tt.header != "" {
+				req.Header.Set("Authorization", tt.header)
+			}
+			got := extractBearerToken(req)
+			if got != tt.want {
+				t.Errorf("extractBearerToken() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// ==================== Context Getter Tests ====================
+
+func TestGetUserID_Success(t *testing.T) {
+	userID := uuid.New()
+	ctx := context.WithValue(context.Background(), UserIDKey, userID)
+
+	got, ok := GetUserID(ctx)
+	if !ok {
+		t.Fatal("expected user ID in context")
+	}
+	if got != userID {
+		t.Errorf("user ID = %v, want %v", got, userID)
+	}
+}
+
+func TestGetUserID_Missing(t *testing.T) {
+	_, ok := GetUserID(context.Background())
+	if ok {
+		t.Error("expected no user ID in empty context")
+	}
+}
+
+func TestGetUser_Success(t *testing.T) {
+	user := &domain.User{ID: uuid.New(), Email: "test@example.com"}
+	ctx := context.WithValue(context.Background(), UserKey, user)
+
+	got, ok := GetUser(ctx)
+	if !ok {
+		t.Fatal("expected user in context")
+	}
+	if got.Email != "test@example.com" {
+		t.Errorf("user email = %q, want %q", got.Email, "test@example.com")
+	}
+}
+
+func TestGetUser_Missing(t *testing.T) {
+	_, ok := GetUser(context.Background())
+	if ok {
+		t.Error("expected no user in empty context")
 	}
 }

--- a/backend/server.go
+++ b/backend/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/joho/godotenv"
 	"github.com/rs/cors"
 	"github.com/swatkatz/babybaton/backend/graph"
+	"github.com/swatkatz/babybaton/backend/internal/auth"
 	"github.com/swatkatz/babybaton/backend/internal/middleware"
 	"github.com/swatkatz/babybaton/backend/internal/store/postgres"
 	"github.com/vektah/gqlparser/v2/ast"
@@ -44,6 +45,18 @@ func main() {
 	}
 	defer store.Close()
 	log.Println("Successfully connected to database")
+
+	// Initialize auth verifier (optional — falls back to header-only auth if no JWT secret)
+	var authMiddleware func(http.Handler) http.Handler
+	if jwtSecret := os.Getenv("SUPABASE_JWT_SECRET"); jwtSecret != "" {
+		verifier := auth.NewSupabaseVerifier(jwtSecret)
+		dualAuth := middleware.NewDualAuthMiddleware(verifier, store)
+		authMiddleware = dualAuth.Handler
+		log.Println("Dual auth enabled (JWT + header-based)")
+	} else {
+		authMiddleware = middleware.AuthMiddleware
+		log.Println("Header-based auth only (SUPABASE_JWT_SECRET not set)")
+	}
 
 	// Create resolver with store
 	resolver := graph.NewResolver(store)
@@ -85,7 +98,7 @@ func main() {
 	})
 
 	http.Handle("/", playground.Handler("GraphQL playground", "/query"))
-	http.Handle("/query", c.Handler(middleware.AuthMiddleware(srv)))
+	http.Handle("/query", c.Handler(authMiddleware(srv)))
 
 	log.Printf("connect to http://localhost:%s/ for GraphQL playground", port)
 	log.Fatal(http.ListenAndServe(":"+port, nil))


### PR DESCRIPTION
## Summary

Closes #24

- Add dual auth middleware: JWT + header-based auth (#24)

## Test plan

- [ ] Verify the changes address the issue requirements
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)