### PR TITLE
Fix #25: Backend resolver changes: user-based auth + migration mutation

### DIFF
--- a/backend/graph/generated.go
+++ b/backend/graph/generated.go
@@ -128,11 +128,12 @@ type ComplexityRoot struct {
 	Mutation struct {
 		AddActivities       func(childComplexity int, activities []*model.ActivityInput) int
 		CompleteCareSession func(childComplexity int, notes *string) int
-		CreateFamily        func(childComplexity int, familyName string, password string, babyName string, caregiverName string, deviceID string, deviceName *string) int
+		CreateFamily        func(childComplexity int, familyName string, password string, babyName string, caregiverName string, deviceID *string, deviceName *string) int
 		DeleteActivity      func(childComplexity int, activityID string) int
 		EndActivity         func(childComplexity int, activityID string, endTime *time.Time) int
-		JoinFamily          func(childComplexity int, familyName string, password string, caregiverName string, deviceID string, deviceName *string) int
+		JoinFamily          func(childComplexity int, familyName string, password string, caregiverName string, deviceID *string, deviceName *string) int
 		LeaveFamily         func(childComplexity int) int
+		LinkCaregiverToUser func(childComplexity int, caregiverID string) int
 		ParseVoiceInput     func(childComplexity int, audioFile graphql.Upload) int
 		StartCareSession    func(childComplexity int) int
 		UpdateActivity      func(childComplexity int, activityID string, input model.ActivityInput) int
@@ -165,6 +166,7 @@ type ComplexityRoot struct {
 		GetCareSession           func(childComplexity int, id string) int
 		GetCurrentSession        func(childComplexity int) int
 		GetMyCaregiver           func(childComplexity int) int
+		GetMyFamilies            func(childComplexity int) int
 		GetMyFamily              func(childComplexity int) int
 		GetRecentCareSessions    func(childComplexity int, limit *int32) int
 		PredictNextFeed          func(childComplexity int) int
@@ -186,8 +188,9 @@ type ComplexityRoot struct {
 }
 
 type MutationResolver interface {
-	CreateFamily(ctx context.Context, familyName string, password string, babyName string, caregiverName string, deviceID string, deviceName *string) (*model.AuthResult, error)
-	JoinFamily(ctx context.Context, familyName string, password string, caregiverName string, deviceID string, deviceName *string) (*model.AuthResult, error)
+	CreateFamily(ctx context.Context, familyName string, password string, babyName string, caregiverName string, deviceID *string, deviceName *string) (*model.AuthResult, error)
+	JoinFamily(ctx context.Context, familyName string, password string, caregiverName string, deviceID *string, deviceName *string) (*model.AuthResult, error)
+	LinkCaregiverToUser(ctx context.Context, caregiverID string) (*model.Caregiver, error)
 	UpdateBabyName(ctx context.Context, babyName string) (*model.Family, error)
 	LeaveFamily(ctx context.Context) (bool, error)
 	StartCareSession(ctx context.Context) (*model.CareSession, error)
@@ -202,6 +205,7 @@ type QueryResolver interface {
 	CheckFamilyNameAvailable(ctx context.Context, name string) (bool, error)
 	GetMyFamily(ctx context.Context) (*model.Family, error)
 	GetMyCaregiver(ctx context.Context) (*model.Caregiver, error)
+	GetMyFamilies(ctx context.Context) ([]*model.Family, error)
 	GetRecentCareSessions(ctx context.Context, limit *int32) ([]*model.CareSession, error)
 	GetCurrentSession(ctx context.Context) (*model.CareSession, error)
 	GetCareSession(ctx context.Context, id string) (*model.CareSession, error)
@@ -574,7 +578,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.CreateFamily(childComplexity, args["familyName"].(string), args["password"].(string), args["babyName"].(string), args["caregiverName"].(string), args["deviceId"].(string), args["deviceName"].(*string)), true
+		return e.complexity.Mutation.CreateFamily(childComplexity, args["familyName"].(string), args["password"].(string), args["babyName"].(string), args["caregiverName"].(string), args["deviceId"].(*string), args["deviceName"].(*string)), true
 	case "Mutation.deleteActivity":
 		if e.complexity.Mutation.DeleteActivity == nil {
 			break
@@ -607,13 +611,24 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.JoinFamily(childComplexity, args["familyName"].(string), args["password"].(string), args["caregiverName"].(string), args["deviceId"].(string), args["deviceName"].(*string)), true
+		return e.complexity.Mutation.JoinFamily(childComplexity, args["familyName"].(string), args["password"].(string), args["caregiverName"].(string), args["deviceId"].(*string), args["deviceName"].(*string)), true
 	case "Mutation.leaveFamily":
 		if e.complexity.Mutation.LeaveFamily == nil {
 			break
 		}
 
 		return e.complexity.Mutation.LeaveFamily(childComplexity), true
+	case "Mutation.linkCaregiverToUser":
+		if e.complexity.Mutation.LinkCaregiverToUser == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_linkCaregiverToUser_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.LinkCaregiverToUser(childComplexity, args["caregiverId"].(string)), true
 	case "Mutation.parseVoiceInput":
 		if e.complexity.Mutation.ParseVoiceInput == nil {
 			break
@@ -763,6 +778,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.GetMyCaregiver(childComplexity), true
+	case "Query.getMyFamilies":
+		if e.complexity.Query.GetMyFamilies == nil {
+			break
+		}
+
+		return e.complexity.Query.GetMyFamilies(childComplexity), true
 	case "Query.getMyFamily":
 		if e.complexity.Query.GetMyFamily == nil {
 			break
@@ -1132,6 +1153,7 @@ type Query {
   checkFamilyNameAvailable(name: String!): Boolean!
   getMyFamily: Family
   getMyCaregiver: Caregiver
+  getMyFamilies: [Family!]!
 
   # Care Sessions (automatically scoped to authenticated caregiver's family)
   getRecentCareSessions(limit: Int): [CareSession!]!
@@ -1150,7 +1172,7 @@ type Mutation {
     password: String!
     babyName: String!
     caregiverName: String!
-    deviceId: String!
+    deviceId: String
     deviceName: String
   ): AuthResult!
 
@@ -1158,9 +1180,11 @@ type Mutation {
     familyName: String!
     password: String!
     caregiverName: String!
-    deviceId: String!
+    deviceId: String
     deviceName: String
   ): AuthResult!
+
+  linkCaregiverToUser(caregiverId: ID!): Caregiver!
 
   updateBabyName(babyName: String!): Family!
 
@@ -1234,7 +1258,7 @@ func (ec *executionContext) field_Mutation_createFamily_args(ctx context.Context
 		return nil, err
 	}
 	args["caregiverName"] = arg3
-	arg4, err := graphql.ProcessArgField(ctx, rawArgs, "deviceId", ec.unmarshalNString2string)
+	arg4, err := graphql.ProcessArgField(ctx, rawArgs, "deviceId", ec.unmarshalOString2ᚖstring)
 	if err != nil {
 		return nil, err
 	}
@@ -1292,7 +1316,7 @@ func (ec *executionContext) field_Mutation_joinFamily_args(ctx context.Context, 
 		return nil, err
 	}
 	args["caregiverName"] = arg2
-	arg3, err := graphql.ProcessArgField(ctx, rawArgs, "deviceId", ec.unmarshalNString2string)
+	arg3, err := graphql.ProcessArgField(ctx, rawArgs, "deviceId", ec.unmarshalOString2ᚖstring)
 	if err != nil {
 		return nil, err
 	}
@@ -1302,6 +1326,17 @@ func (ec *executionContext) field_Mutation_joinFamily_args(ctx context.Context, 
 		return nil, err
 	}
 	args["deviceName"] = arg4
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_linkCaregiverToUser_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "caregiverId", ec.unmarshalNID2string)
+	if err != nil {
+		return nil, err
+	}
+	args["caregiverId"] = arg0
 	return args, nil
 }
 
@@ -3024,7 +3059,7 @@ func (ec *executionContext) _Mutation_createFamily(ctx context.Context, field gr
 		ec.fieldContext_Mutation_createFamily,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().CreateFamily(ctx, fc.Args["familyName"].(string), fc.Args["password"].(string), fc.Args["babyName"].(string), fc.Args["caregiverName"].(string), fc.Args["deviceId"].(string), fc.Args["deviceName"].(*string))
+			return ec.resolvers.Mutation().CreateFamily(ctx, fc.Args["familyName"].(string), fc.Args["password"].(string), fc.Args["babyName"].(string), fc.Args["caregiverName"].(string), fc.Args["deviceId"].(*string), fc.Args["deviceName"].(*string))
 		},
 		nil,
 		ec.marshalNAuthResult2ᚖgithubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐAuthResult,
@@ -3075,7 +3110,7 @@ func (ec *executionContext) _Mutation_joinFamily(ctx context.Context, field grap
 		ec.fieldContext_Mutation_joinFamily,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().JoinFamily(ctx, fc.Args["familyName"].(string), fc.Args["password"].(string), fc.Args["caregiverName"].(string), fc.Args["deviceId"].(string), fc.Args["deviceName"].(*string))
+			return ec.resolvers.Mutation().JoinFamily(ctx, fc.Args["familyName"].(string), fc.Args["password"].(string), fc.Args["caregiverName"].(string), fc.Args["deviceId"].(*string), fc.Args["deviceName"].(*string))
 		},
 		nil,
 		ec.marshalNAuthResult2ᚖgithubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐAuthResult,
@@ -3112,6 +3147,61 @@ func (ec *executionContext) fieldContext_Mutation_joinFamily(ctx context.Context
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_joinFamily_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_linkCaregiverToUser(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Mutation_linkCaregiverToUser,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.resolvers.Mutation().LinkCaregiverToUser(ctx, fc.Args["caregiverId"].(string))
+		},
+		nil,
+		ec.marshalNCaregiver2ᚖgithubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐCaregiver,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Mutation_linkCaregiverToUser(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Caregiver_id(ctx, field)
+			case "familyId":
+				return ec.fieldContext_Caregiver_familyId(ctx, field)
+			case "name":
+				return ec.fieldContext_Caregiver_name(ctx, field)
+			case "deviceId":
+				return ec.fieldContext_Caregiver_deviceId(ctx, field)
+			case "deviceName":
+				return ec.fieldContext_Caregiver_deviceName(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Caregiver_createdAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Caregiver", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_linkCaregiverToUser_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -4063,6 +4153,49 @@ func (ec *executionContext) fieldContext_Query_getMyCaregiver(_ context.Context,
 				return ec.fieldContext_Caregiver_createdAt(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Caregiver", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_getMyFamilies(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_getMyFamilies,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.Query().GetMyFamilies(ctx)
+		},
+		nil,
+		ec.marshalNFamily2ᚕᚖgithubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐFamilyᚄ,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_getMyFamilies(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Family_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Family_name(ctx, field)
+			case "babyName":
+				return ec.fieldContext_Family_babyName(ctx, field)
+			case "password":
+				return ec.fieldContext_Family_password(ctx, field)
+			case "caregivers":
+				return ec.fieldContext_Family_caregivers(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Family_createdAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Family", field.Name)
 		},
 	}
 	return fc, nil
@@ -6847,6 +6980,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "linkCaregiverToUser":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_linkCaregiverToUser(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "updateBabyName":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_updateBabyName(ctx, field)
@@ -7150,6 +7290,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_getMyCaregiver(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "getMyFamilies":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_getMyFamilies(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 
@@ -7900,6 +8062,10 @@ func (ec *executionContext) marshalNCareSessionSummary2ᚖgithubᚗcomᚋswatkat
 	return ec._CareSessionSummary(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNCaregiver2githubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐCaregiver(ctx context.Context, sel ast.SelectionSet, v model.Caregiver) graphql.Marshaler {
+	return ec._Caregiver(ctx, sel, &v)
+}
+
 func (ec *executionContext) marshalNCaregiver2ᚕᚖgithubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐCaregiverᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Caregiver) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
@@ -7972,6 +8138,50 @@ func (ec *executionContext) marshalNDateTime2timeᚐTime(ctx context.Context, se
 
 func (ec *executionContext) marshalNFamily2githubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐFamily(ctx context.Context, sel ast.SelectionSet, v model.Family) graphql.Marshaler {
 	return ec._Family(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNFamily2ᚕᚖgithubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐFamilyᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Family) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNFamily2ᚖgithubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐFamily(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) marshalNFamily2ᚖgithubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐFamily(ctx context.Context, sel ast.SelectionSet, v *model.Family) graphql.Marshaler {

--- a/backend/graph/mock_store_test.go
+++ b/backend/graph/mock_store_test.go
@@ -1,0 +1,187 @@
+package graph
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/swatkatz/babybaton/backend/internal/domain"
+	"golang.org/x/crypto/bcrypt"
+)
+
+var errNotFound = fmt.Errorf("not found")
+
+func hashPassword(pw string) string {
+	h, _ := bcrypt.GenerateFromPassword([]byte(pw), bcrypt.MinCost)
+	return string(h)
+}
+
+type mockStore struct {
+	// Configurable return values
+	family                        *domain.Family
+	familyErr                     error
+	familyNameExists              bool
+	familiesByUser                []*domain.Family
+	caregiverByID                 *domain.Caregiver
+	caregiverByIDErr              error
+	caregiverByDeviceID           *domain.Caregiver
+	getCaregiverByDeviceIDErr     error
+	caregiverByUserAndFamily      *domain.Caregiver
+	getCaregiverByUserAndFamilyErr error
+
+	// Tracking calls
+	lastCreatedCaregiver      *domain.Caregiver
+	linkCaregiverToUserCalled bool
+	deleteCaregiverCalled     bool
+}
+
+func newMockStore() *mockStore {
+	return &mockStore{}
+}
+
+// Family operations
+func (m *mockStore) CreateFamilyWithCaregiver(_ context.Context, _ *domain.Family, caregiver *domain.Caregiver) error {
+	m.lastCreatedCaregiver = caregiver
+	return nil
+}
+
+func (m *mockStore) GetFamilyByID(_ context.Context, _ uuid.UUID) (*domain.Family, error) {
+	if m.family != nil {
+		return m.family, nil
+	}
+	return nil, errNotFound
+}
+
+func (m *mockStore) GetFamilyByName(_ context.Context, _ string) (*domain.Family, error) {
+	if m.family != nil {
+		return m.family, nil
+	}
+	if m.familyErr != nil {
+		return nil, m.familyErr
+	}
+	return nil, errNotFound
+}
+
+func (m *mockStore) UpdateFamily(_ context.Context, _ *domain.Family) error { return nil }
+func (m *mockStore) DeleteFamily(_ context.Context, _ uuid.UUID) error      { return nil }
+
+func (m *mockStore) FamilyNameExists(_ context.Context, _ string) (bool, error) {
+	return m.familyNameExists, nil
+}
+
+func (m *mockStore) GetFamiliesByUserID(_ context.Context, _ uuid.UUID) ([]*domain.Family, error) {
+	return m.familiesByUser, nil
+}
+
+// User operations
+func (m *mockStore) CreateUser(_ context.Context, _ *domain.User) error { return nil }
+func (m *mockStore) GetUserBySupabaseID(_ context.Context, _ string) (*domain.User, error) {
+	return nil, errNotFound
+}
+func (m *mockStore) GetUserByID(_ context.Context, _ uuid.UUID) (*domain.User, error) {
+	return nil, errNotFound
+}
+
+// Caregiver operations
+func (m *mockStore) CreateCaregiver(_ context.Context, caregiver *domain.Caregiver) error {
+	m.lastCreatedCaregiver = caregiver
+	return nil
+}
+
+func (m *mockStore) GetCaregiverByID(_ context.Context, _ uuid.UUID) (*domain.Caregiver, error) {
+	if m.caregiverByID != nil {
+		return m.caregiverByID, nil
+	}
+	if m.caregiverByIDErr != nil {
+		return nil, m.caregiverByIDErr
+	}
+	return nil, errNotFound
+}
+
+func (m *mockStore) GetCaregiverByDeviceID(_ context.Context, _ string) (*domain.Caregiver, error) {
+	if m.caregiverByDeviceID != nil {
+		return m.caregiverByDeviceID, nil
+	}
+	if m.getCaregiverByDeviceIDErr != nil {
+		return nil, m.getCaregiverByDeviceIDErr
+	}
+	return nil, errNotFound
+}
+
+func (m *mockStore) GetCaregiverByUserAndFamily(_ context.Context, _ uuid.UUID, _ uuid.UUID) (*domain.Caregiver, error) {
+	if m.caregiverByUserAndFamily != nil {
+		return m.caregiverByUserAndFamily, nil
+	}
+	if m.getCaregiverByUserAndFamilyErr != nil {
+		return nil, m.getCaregiverByUserAndFamilyErr
+	}
+	return nil, errNotFound
+}
+
+func (m *mockStore) GetCaregiversByFamily(_ context.Context, _ uuid.UUID) ([]*domain.Caregiver, error) {
+	return nil, nil
+}
+
+func (m *mockStore) UpdateCaregiver(_ context.Context, _ *domain.Caregiver) error { return nil }
+
+func (m *mockStore) LinkCaregiverToUser(_ context.Context, _ uuid.UUID, _ uuid.UUID) error {
+	m.linkCaregiverToUserCalled = true
+	return nil
+}
+
+func (m *mockStore) DeleteCaregiver(_ context.Context, _ uuid.UUID) error {
+	m.deleteCaregiverCalled = true
+	return nil
+}
+
+// Care Session operations
+func (m *mockStore) CreateCareSession(_ context.Context, _ *domain.CareSession) error { return nil }
+func (m *mockStore) GetCareSessionByID(_ context.Context, _ uuid.UUID) (*domain.CareSession, error) {
+	return nil, errNotFound
+}
+func (m *mockStore) GetInProgressSessionForFamily(_ context.Context, _ uuid.UUID) (*domain.CareSession, error) {
+	return nil, nil
+}
+func (m *mockStore) GetRecentCareSessionsForFamily(_ context.Context, _ uuid.UUID, _ int) ([]*domain.CareSession, error) {
+	return nil, nil
+}
+func (m *mockStore) UpdateCareSession(_ context.Context, _ *domain.CareSession) error { return nil }
+func (m *mockStore) DeleteCareSession(_ context.Context, _ uuid.UUID) error            { return nil }
+
+// Activity operations
+func (m *mockStore) CreateActivity(_ context.Context, _ *domain.Activity) error { return nil }
+func (m *mockStore) GetActivityByID(_ context.Context, _ uuid.UUID) (*domain.Activity, error) {
+	return nil, errNotFound
+}
+func (m *mockStore) GetActivitiesForSession(_ context.Context, _ uuid.UUID) ([]*domain.Activity, error) {
+	return nil, nil
+}
+func (m *mockStore) DeleteActivity(_ context.Context, _ uuid.UUID) error { return nil }
+
+// Activity detail operations
+func (m *mockStore) CreateFeedDetails(_ context.Context, _ *domain.FeedDetails) error { return nil }
+func (m *mockStore) GetFeedDetails(_ context.Context, _ uuid.UUID) (*domain.FeedDetails, error) {
+	return nil, errNotFound
+}
+func (m *mockStore) GetRecentFeedDetailsForFamily(_ context.Context, _ uuid.UUID, _ int) ([]*domain.FeedDetails, error) {
+	return nil, nil
+}
+func (m *mockStore) UpdateFeedDetails(_ context.Context, _ *domain.FeedDetails) error { return nil }
+
+func (m *mockStore) CreateDiaperDetails(_ context.Context, _ *domain.DiaperDetails) error {
+	return nil
+}
+func (m *mockStore) GetDiaperDetails(_ context.Context, _ uuid.UUID) (*domain.DiaperDetails, error) {
+	return nil, errNotFound
+}
+func (m *mockStore) UpdateDiaperDetails(_ context.Context, _ *domain.DiaperDetails) error {
+	return nil
+}
+
+func (m *mockStore) CreateSleepDetails(_ context.Context, _ *domain.SleepDetails) error { return nil }
+func (m *mockStore) GetSleepDetails(_ context.Context, _ uuid.UUID) (*domain.SleepDetails, error) {
+	return nil, errNotFound
+}
+func (m *mockStore) UpdateSleepDetails(_ context.Context, _ *domain.SleepDetails) error { return nil }
+
+func (m *mockStore) Close() error { return nil }

--- a/backend/graph/schema.resolvers.go
+++ b/backend/graph/schema.resolvers.go
@@ -23,7 +23,7 @@ import (
 )
 
 // CreateFamily is the resolver for the createFamily field.
-func (r *mutationResolver) CreateFamily(ctx context.Context, familyName string, password string, babyName string, caregiverName string, deviceID string, deviceName *string) (*model.AuthResult, error) {
+func (r *mutationResolver) CreateFamily(ctx context.Context, familyName string, password string, babyName string, caregiverName string, deviceID *string, deviceName *string) (*model.AuthResult, error) {
 	// Validate password length
 	if len(password) < 6 {
 		return &model.AuthResult{
@@ -72,14 +72,30 @@ func (r *mutationResolver) CreateFamily(ctx context.Context, familyName string, 
 		UpdatedAt:    now,
 	}
 
+	// Determine auth path: JWT user-based or legacy device-based
+	userID, hasUser := middleware.GetUserID(ctx)
+
 	caregiver := &domain.Caregiver{
 		ID:         caregiverID,
 		FamilyID:   familyID,
 		Name:       caregiverName,
-		DeviceID:   &deviceID,
 		DeviceName: deviceName,
 		CreatedAt:  now,
 		UpdatedAt:  now,
+	}
+
+	if hasUser {
+		// User-based auth: link caregiver to user, ignore deviceId
+		caregiver.UserID = &userID
+	} else {
+		// Legacy device-based auth: deviceId is required
+		if deviceID == nil || *deviceID == "" {
+			return &model.AuthResult{
+				Success: false,
+				Error:   stringPtr("deviceId is required for device-based authentication"),
+			}, nil
+		}
+		caregiver.DeviceID = deviceID
 	}
 
 	// Create family and caregiver atomically
@@ -94,14 +110,14 @@ func (r *mutationResolver) CreateFamily(ctx context.Context, familyName string, 
 	// Convert to GraphQL types
 	return &model.AuthResult{
 		Success:   true,
-		Family:    mapper.FamilyToGraphQL(family),       // ← Use mapper
-		Caregiver: mapper.CaregiverToGraphQL(caregiver), // ← Use mapper
+		Family:    mapper.FamilyToGraphQL(family),
+		Caregiver: mapper.CaregiverToGraphQL(caregiver),
 		Error:     nil,
 	}, nil
 }
 
 // JoinFamily is the resolver for the joinFamily field.
-func (r *mutationResolver) JoinFamily(ctx context.Context, familyName string, password string, caregiverName string, deviceID string, deviceName *string) (*model.AuthResult, error) {
+func (r *mutationResolver) JoinFamily(ctx context.Context, familyName string, password string, caregiverName string, deviceID *string, deviceName *string) (*model.AuthResult, error) {
 	family, err := r.store.GetFamilyByName(ctx, familyName)
 	if err != nil {
 		return &model.AuthResult{
@@ -119,8 +135,63 @@ func (r *mutationResolver) JoinFamily(ctx context.Context, familyName string, pa
 		}, nil
 	}
 
+	// Determine auth path: JWT user-based or legacy device-based
+	userID, hasUser := middleware.GetUserID(ctx)
+
+	if hasUser {
+		// User-based auth path
+		// Check if user already has a caregiver in this family
+		existingCaregiver, err := r.store.GetCaregiverByUserAndFamily(ctx, userID, family.ID)
+		if err == nil && existingCaregiver != nil {
+			// Re-authentication: user already in this family
+			return &model.AuthResult{
+				Success:   true,
+				Family:    mapper.FamilyToGraphQL(family),
+				Caregiver: mapper.CaregiverToGraphQL(existingCaregiver),
+				Error:     nil,
+			}, nil
+		}
+
+		// Create new caregiver linked to user
+		caregiverID := uuid.New()
+		now := time.Now()
+
+		caregiver := &domain.Caregiver{
+			ID:         caregiverID,
+			FamilyID:   family.ID,
+			UserID:     &userID,
+			Name:       caregiverName,
+			DeviceName: deviceName,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		}
+
+		err = r.store.CreateCaregiver(ctx, caregiver)
+		if err != nil {
+			return &model.AuthResult{
+				Success: false,
+				Error:   stringPtr(fmt.Sprintf("Failed to join family: %v", err)),
+			}, nil
+		}
+
+		return &model.AuthResult{
+			Success:   true,
+			Family:    mapper.FamilyToGraphQL(family),
+			Caregiver: mapper.CaregiverToGraphQL(caregiver),
+			Error:     nil,
+		}, nil
+	}
+
+	// Legacy device-based auth path
+	if deviceID == nil || *deviceID == "" {
+		return &model.AuthResult{
+			Success: false,
+			Error:   stringPtr("deviceId is required for device-based authentication"),
+		}, nil
+	}
+
 	// Check if device already exists
-	existingCaregiver, err := r.store.GetCaregiverByDeviceID(ctx, deviceID)
+	existingCaregiver, err := r.store.GetCaregiverByDeviceID(ctx, *deviceID)
 
 	// Case 1: Device exists in THIS family → Re-authentication (allow it!)
 	if err == nil && existingCaregiver != nil && existingCaregiver.FamilyID == family.ID {
@@ -148,7 +219,7 @@ func (r *mutationResolver) JoinFamily(ctx context.Context, familyName string, pa
 		ID:         caregiverID,
 		FamilyID:   family.ID,
 		Name:       caregiverName,
-		DeviceID:   &deviceID,
+		DeviceID:   deviceID,
 		DeviceName: deviceName,
 		CreatedAt:  now,
 		UpdatedAt:  now,
@@ -168,6 +239,44 @@ func (r *mutationResolver) JoinFamily(ctx context.Context, familyName string, pa
 		Caregiver: mapper.CaregiverToGraphQL(caregiver),
 		Error:     nil,
 	}, nil
+}
+
+// LinkCaregiverToUser is the resolver for the linkCaregiverToUser field.
+func (r *mutationResolver) LinkCaregiverToUser(ctx context.Context, caregiverID string) (*model.Caregiver, error) {
+	// Require JWT-based user auth
+	userID, hasUser := middleware.GetUserID(ctx)
+	if !hasUser {
+		return nil, fmt.Errorf("authentication required: must be authenticated with a user account")
+	}
+
+	caregiverUUID, err := uuid.Parse(caregiverID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid caregiver ID: %w", err)
+	}
+
+	// Verify caregiver exists
+	caregiver, err := r.store.GetCaregiverByID(ctx, caregiverUUID)
+	if err != nil {
+		return nil, fmt.Errorf("caregiver not found: %w", err)
+	}
+
+	// Verify caregiver is not already linked to a user
+	if caregiver.UserID != nil {
+		return nil, fmt.Errorf("caregiver is already linked to a user")
+	}
+
+	// Link caregiver to user
+	if err := r.store.LinkCaregiverToUser(ctx, caregiverUUID, userID); err != nil {
+		return nil, fmt.Errorf("failed to link caregiver to user: %w", err)
+	}
+
+	// Reload to get updated state
+	caregiver, err = r.store.GetCaregiverByID(ctx, caregiverUUID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reload caregiver: %w", err)
+	}
+
+	return mapper.CaregiverToGraphQL(caregiver), nil
 }
 
 // UpdateBabyName is the resolver for the updateBabyName field.
@@ -819,6 +928,27 @@ func (r *queryResolver) GetMyCaregiver(ctx context.Context) (*model.Caregiver, e
 	}
 
 	return mapper.CaregiverToGraphQL(caregiver), nil
+}
+
+// GetMyFamilies is the resolver for the getMyFamilies field.
+func (r *queryResolver) GetMyFamilies(ctx context.Context) ([]*model.Family, error) {
+	// Require JWT-based user auth
+	userID, hasUser := middleware.GetUserID(ctx)
+	if !hasUser {
+		return nil, fmt.Errorf("authentication required: must be authenticated with a user account")
+	}
+
+	families, err := r.store.GetFamiliesByUserID(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get families: %w", err)
+	}
+
+	result := make([]*model.Family, len(families))
+	for i, f := range families {
+		result[i] = mapper.FamilyToGraphQL(f)
+	}
+
+	return result, nil
 }
 
 // GetRecentCareSessions is the resolver for the getRecentCareSessions field.

--- a/backend/graph/schema.resolvers_test.go
+++ b/backend/graph/schema.resolvers_test.go
@@ -1,0 +1,516 @@
+package graph
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/swatkatz/babybaton/backend/internal/domain"
+	"github.com/swatkatz/babybaton/backend/internal/middleware"
+)
+
+// withUserID sets a user ID in context (simulates JWT auth path)
+func withUserID(ctx context.Context, userID uuid.UUID) context.Context {
+	return context.WithValue(ctx, middleware.UserIDKey, userID)
+}
+
+// withAuth sets caregiver and family IDs in context (simulates legacy auth path)
+func withAuth(ctx context.Context, caregiverID, familyID uuid.UUID) context.Context {
+	ctx = context.WithValue(ctx, middleware.CaregiverIDKey, caregiverID)
+	ctx = context.WithValue(ctx, middleware.FamilyIDKey, familyID)
+	return ctx
+}
+
+// ==================== CreateFamily Tests ====================
+
+func TestCreateFamily_DeviceBased(t *testing.T) {
+	store := newMockStore()
+	resolver := NewResolver(store)
+	mr := &mutationResolver{resolver}
+	ctx := context.Background()
+
+	deviceID := "test-device-123"
+	deviceName := "iPhone"
+	result, err := mr.CreateFamily(ctx, "TestFamily", "password123", "Baby", "Mom", &deviceID, &deviceName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success, got error: %v", *result.Error)
+	}
+	if result.Family == nil {
+		t.Fatal("expected family in result")
+	}
+	if result.Caregiver == nil {
+		t.Fatal("expected caregiver in result")
+	}
+	if result.Family.Name != "TestFamily" {
+		t.Errorf("expected family name %q, got %q", "TestFamily", result.Family.Name)
+	}
+}
+
+func TestCreateFamily_DeviceBased_MissingDeviceID(t *testing.T) {
+	store := newMockStore()
+	resolver := NewResolver(store)
+	mr := &mutationResolver{resolver}
+	ctx := context.Background()
+
+	result, err := mr.CreateFamily(ctx, "TestFamily", "password123", "Baby", "Mom", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Success {
+		t.Fatal("expected failure when deviceId is missing for device-based auth")
+	}
+	if result.Error == nil || *result.Error != "deviceId is required for device-based authentication" {
+		t.Errorf("unexpected error message: %v", result.Error)
+	}
+}
+
+func TestCreateFamily_UserBased(t *testing.T) {
+	store := newMockStore()
+	resolver := NewResolver(store)
+	mr := &mutationResolver{resolver}
+
+	userID := uuid.New()
+	ctx := withUserID(context.Background(), userID)
+
+	result, err := mr.CreateFamily(ctx, "TestFamily", "password123", "Baby", "Mom", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success, got error: %v", *result.Error)
+	}
+	if result.Family == nil || result.Caregiver == nil {
+		t.Fatal("expected family and caregiver in result")
+	}
+
+	// Verify the caregiver was created with user_id (check the store)
+	if store.lastCreatedCaregiver == nil {
+		t.Fatal("expected caregiver to be stored")
+	}
+	if store.lastCreatedCaregiver.UserID == nil || *store.lastCreatedCaregiver.UserID != userID {
+		t.Error("expected caregiver to be linked to user")
+	}
+	if store.lastCreatedCaregiver.DeviceID != nil {
+		t.Error("expected no device ID for user-based caregiver")
+	}
+}
+
+func TestCreateFamily_ShortPassword(t *testing.T) {
+	store := newMockStore()
+	resolver := NewResolver(store)
+	mr := &mutationResolver{resolver}
+	ctx := context.Background()
+
+	deviceID := "test-device"
+	result, err := mr.CreateFamily(ctx, "TestFamily", "short", "Baby", "Mom", &deviceID, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Success {
+		t.Fatal("expected failure for short password")
+	}
+}
+
+func TestCreateFamily_DuplicateName(t *testing.T) {
+	store := newMockStore()
+	store.familyNameExists = true
+	resolver := NewResolver(store)
+	mr := &mutationResolver{resolver}
+	ctx := context.Background()
+
+	deviceID := "test-device"
+	result, err := mr.CreateFamily(ctx, "Existing", "password123", "Baby", "Mom", &deviceID, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Success {
+		t.Fatal("expected failure for duplicate family name")
+	}
+}
+
+// ==================== JoinFamily Tests ====================
+
+func TestJoinFamily_DeviceBased_NewDevice(t *testing.T) {
+	familyID := uuid.New()
+	store := newMockStore()
+	store.family = &domain.Family{
+		ID:           familyID,
+		Name:         "TestFamily",
+		PasswordHash: hashPassword("password123"),
+		Password:     "password123",
+		BabyName:     "Baby",
+	}
+	store.getCaregiverByDeviceIDErr = errNotFound
+
+	resolver := NewResolver(store)
+	mr := &mutationResolver{resolver}
+	ctx := context.Background()
+
+	deviceID := "new-device"
+	result, err := mr.JoinFamily(ctx, "TestFamily", "password123", "Dad", &deviceID, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success, got error: %v", *result.Error)
+	}
+	if result.Caregiver == nil {
+		t.Fatal("expected caregiver in result")
+	}
+}
+
+func TestJoinFamily_DeviceBased_ExistingDeviceSameFamily(t *testing.T) {
+	familyID := uuid.New()
+	caregiverID := uuid.New()
+	deviceID := "existing-device"
+
+	store := newMockStore()
+	store.family = &domain.Family{
+		ID:           familyID,
+		Name:         "TestFamily",
+		PasswordHash: hashPassword("password123"),
+		Password:     "password123",
+		BabyName:     "Baby",
+	}
+	store.caregiverByDeviceID = &domain.Caregiver{
+		ID:       caregiverID,
+		FamilyID: familyID,
+		Name:     "Mom",
+		DeviceID: &deviceID,
+	}
+
+	resolver := NewResolver(store)
+	mr := &mutationResolver{resolver}
+	ctx := context.Background()
+
+	result, err := mr.JoinFamily(ctx, "TestFamily", "password123", "Mom", &deviceID, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Fatal("expected success for re-auth")
+	}
+	if result.Caregiver.ID != caregiverID.String() {
+		t.Error("expected existing caregiver to be returned")
+	}
+}
+
+func TestJoinFamily_DeviceBased_ExistingDeviceDifferentFamily(t *testing.T) {
+	familyID := uuid.New()
+	otherFamilyID := uuid.New()
+	deviceID := "existing-device"
+
+	store := newMockStore()
+	store.family = &domain.Family{
+		ID:           familyID,
+		Name:         "TestFamily",
+		PasswordHash: hashPassword("password123"),
+		Password:     "password123",
+		BabyName:     "Baby",
+	}
+	store.caregiverByDeviceID = &domain.Caregiver{
+		ID:       uuid.New(),
+		FamilyID: otherFamilyID,
+		Name:     "Mom",
+		DeviceID: &deviceID,
+	}
+
+	resolver := NewResolver(store)
+	mr := &mutationResolver{resolver}
+	ctx := context.Background()
+
+	result, err := mr.JoinFamily(ctx, "TestFamily", "password123", "Mom", &deviceID, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Success {
+		t.Fatal("expected failure when device belongs to different family")
+	}
+}
+
+func TestJoinFamily_DeviceBased_MissingDeviceID(t *testing.T) {
+	store := newMockStore()
+	store.family = &domain.Family{
+		ID:           uuid.New(),
+		Name:         "TestFamily",
+		PasswordHash: hashPassword("password123"),
+		Password:     "password123",
+		BabyName:     "Baby",
+	}
+
+	resolver := NewResolver(store)
+	mr := &mutationResolver{resolver}
+	ctx := context.Background()
+
+	result, err := mr.JoinFamily(ctx, "TestFamily", "password123", "Dad", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Success {
+		t.Fatal("expected failure when deviceId is missing")
+	}
+}
+
+func TestJoinFamily_UserBased_NewUser(t *testing.T) {
+	familyID := uuid.New()
+	userID := uuid.New()
+
+	store := newMockStore()
+	store.family = &domain.Family{
+		ID:           familyID,
+		Name:         "TestFamily",
+		PasswordHash: hashPassword("password123"),
+		Password:     "password123",
+		BabyName:     "Baby",
+	}
+	store.getCaregiverByUserAndFamilyErr = errNotFound
+
+	resolver := NewResolver(store)
+	mr := &mutationResolver{resolver}
+	ctx := withUserID(context.Background(), userID)
+
+	result, err := mr.JoinFamily(ctx, "TestFamily", "password123", "Dad", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("expected success, got error: %v", *result.Error)
+	}
+	if store.lastCreatedCaregiver == nil {
+		t.Fatal("expected caregiver to be created")
+	}
+	if store.lastCreatedCaregiver.UserID == nil || *store.lastCreatedCaregiver.UserID != userID {
+		t.Error("expected caregiver to be linked to user")
+	}
+}
+
+func TestJoinFamily_UserBased_ExistingUser(t *testing.T) {
+	familyID := uuid.New()
+	userID := uuid.New()
+	caregiverID := uuid.New()
+
+	store := newMockStore()
+	store.family = &domain.Family{
+		ID:           familyID,
+		Name:         "TestFamily",
+		PasswordHash: hashPassword("password123"),
+		Password:     "password123",
+		BabyName:     "Baby",
+	}
+	store.caregiverByUserAndFamily = &domain.Caregiver{
+		ID:       caregiverID,
+		FamilyID: familyID,
+		UserID:   &userID,
+		Name:     "Dad",
+	}
+
+	resolver := NewResolver(store)
+	mr := &mutationResolver{resolver}
+	ctx := withUserID(context.Background(), userID)
+
+	result, err := mr.JoinFamily(ctx, "TestFamily", "password123", "Dad", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Success {
+		t.Fatal("expected success for re-auth")
+	}
+	if result.Caregiver.ID != caregiverID.String() {
+		t.Error("expected existing caregiver to be returned")
+	}
+}
+
+func TestJoinFamily_WrongPassword(t *testing.T) {
+	store := newMockStore()
+	store.family = &domain.Family{
+		ID:           uuid.New(),
+		Name:         "TestFamily",
+		PasswordHash: hashPassword("password123"),
+		Password:     "password123",
+		BabyName:     "Baby",
+	}
+
+	resolver := NewResolver(store)
+	mr := &mutationResolver{resolver}
+	ctx := context.Background()
+
+	deviceID := "test-device"
+	result, err := mr.JoinFamily(ctx, "TestFamily", "wrongpassword", "Dad", &deviceID, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Success {
+		t.Fatal("expected failure for wrong password")
+	}
+}
+
+// ==================== LinkCaregiverToUser Tests ====================
+
+func TestLinkCaregiverToUser_Success(t *testing.T) {
+	userID := uuid.New()
+	caregiverID := uuid.New()
+	familyID := uuid.New()
+
+	store := newMockStore()
+	store.caregiverByID = &domain.Caregiver{
+		ID:       caregiverID,
+		FamilyID: familyID,
+		Name:     "Mom",
+		UserID:   nil, // not linked yet
+	}
+
+	resolver := NewResolver(store)
+	mr := &mutationResolver{resolver}
+	ctx := withUserID(context.Background(), userID)
+
+	result, err := mr.LinkCaregiverToUser(ctx, caregiverID.String())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected caregiver result")
+	}
+	if !store.linkCaregiverToUserCalled {
+		t.Error("expected LinkCaregiverToUser to be called on store")
+	}
+}
+
+func TestLinkCaregiverToUser_NotAuthenticated(t *testing.T) {
+	store := newMockStore()
+	resolver := NewResolver(store)
+	mr := &mutationResolver{resolver}
+	ctx := context.Background() // no user in context
+
+	_, err := mr.LinkCaregiverToUser(ctx, uuid.New().String())
+	if err == nil {
+		t.Fatal("expected error for unauthenticated request")
+	}
+}
+
+func TestLinkCaregiverToUser_AlreadyLinked(t *testing.T) {
+	userID := uuid.New()
+	otherUserID := uuid.New()
+	caregiverID := uuid.New()
+
+	store := newMockStore()
+	store.caregiverByID = &domain.Caregiver{
+		ID:     caregiverID,
+		Name:   "Mom",
+		UserID: &otherUserID, // already linked
+	}
+
+	resolver := NewResolver(store)
+	mr := &mutationResolver{resolver}
+	ctx := withUserID(context.Background(), userID)
+
+	_, err := mr.LinkCaregiverToUser(ctx, caregiverID.String())
+	if err == nil {
+		t.Fatal("expected error for already-linked caregiver")
+	}
+}
+
+func TestLinkCaregiverToUser_InvalidCaregiverID(t *testing.T) {
+	store := newMockStore()
+	resolver := NewResolver(store)
+	mr := &mutationResolver{resolver}
+	ctx := withUserID(context.Background(), uuid.New())
+
+	_, err := mr.LinkCaregiverToUser(ctx, "not-a-uuid")
+	if err == nil {
+		t.Fatal("expected error for invalid caregiver ID")
+	}
+}
+
+// ==================== GetMyFamilies Tests ====================
+
+func TestGetMyFamilies_Success(t *testing.T) {
+	userID := uuid.New()
+	family1 := &domain.Family{ID: uuid.New(), Name: "Family1", BabyName: "Baby1", Password: "pass1"}
+	family2 := &domain.Family{ID: uuid.New(), Name: "Family2", BabyName: "Baby2", Password: "pass2"}
+
+	store := newMockStore()
+	store.familiesByUser = []*domain.Family{family1, family2}
+
+	resolver := NewResolver(store)
+	qr := &queryResolver{resolver}
+	ctx := withUserID(context.Background(), userID)
+
+	result, err := qr.GetMyFamilies(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 families, got %d", len(result))
+	}
+	if result[0].Name != "Family1" {
+		t.Errorf("expected first family name %q, got %q", "Family1", result[0].Name)
+	}
+}
+
+func TestGetMyFamilies_NotAuthenticated(t *testing.T) {
+	store := newMockStore()
+	resolver := NewResolver(store)
+	qr := &queryResolver{resolver}
+	ctx := context.Background()
+
+	_, err := qr.GetMyFamilies(ctx)
+	if err == nil {
+		t.Fatal("expected error for unauthenticated request")
+	}
+}
+
+func TestGetMyFamilies_Empty(t *testing.T) {
+	userID := uuid.New()
+	store := newMockStore()
+	store.familiesByUser = []*domain.Family{}
+
+	resolver := NewResolver(store)
+	qr := &queryResolver{resolver}
+	ctx := withUserID(context.Background(), userID)
+
+	result, err := qr.GetMyFamilies(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 0 {
+		t.Fatalf("expected 0 families, got %d", len(result))
+	}
+}
+
+// ==================== LeaveFamily Tests ====================
+
+func TestLeaveFamily_Success(t *testing.T) {
+	caregiverID := uuid.New()
+	familyID := uuid.New()
+
+	store := newMockStore()
+	resolver := NewResolver(store)
+	mr := &mutationResolver{resolver}
+	ctx := withAuth(context.Background(), caregiverID, familyID)
+
+	result, err := mr.LeaveFamily(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result {
+		t.Fatal("expected true for successful leave")
+	}
+	if !store.deleteCaregiverCalled {
+		t.Error("expected DeleteCaregiver to be called")
+	}
+}
+
+func TestLeaveFamily_NotAuthenticated(t *testing.T) {
+	store := newMockStore()
+	resolver := NewResolver(store)
+	mr := &mutationResolver{resolver}
+	ctx := context.Background()
+
+	_, err := mr.LeaveFamily(ctx)
+	if err == nil {
+		t.Fatal("expected error for unauthenticated request")
+	}
+}

--- a/backend/internal/middleware/auth_test.go
+++ b/backend/internal/middleware/auth_test.go
@@ -55,6 +55,9 @@ func (m *mockStore) DeleteFamily(ctx context.Context, id uuid.UUID) error       
 func (m *mockStore) FamilyNameExists(ctx context.Context, name string) (bool, error) {
 	return false, nil
 }
+func (m *mockStore) GetFamiliesByUserID(ctx context.Context, userID uuid.UUID) ([]*domain.Family, error) {
+	return nil, nil
+}
 func (m *mockStore) CreateUser(ctx context.Context, user *domain.User) error { return nil }
 func (m *mockStore) GetUserByID(ctx context.Context, id uuid.UUID) (*domain.User, error) {
 	return nil, nil

--- a/backend/internal/store/postgres/family.go
+++ b/backend/internal/store/postgres/family.go
@@ -148,6 +148,46 @@ func (s *PostgresStore) DeleteFamily(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
+// GetFamiliesByUserID retrieves all families where the user has a caregiver
+func (s *PostgresStore) GetFamiliesByUserID(ctx context.Context, userID uuid.UUID) ([]*domain.Family, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT f.id, f.name, f.password_hash, f.password, f.baby_name, f.created_at, f.updated_at
+		FROM families f
+		INNER JOIN caregivers c ON c.family_id = f.id
+		WHERE c.user_id = $1
+		ORDER BY f.created_at ASC
+	`, userID)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to query families by user: %w", err)
+	}
+	defer rows.Close()
+
+	var families []*domain.Family
+	for rows.Next() {
+		family := &domain.Family{}
+		err := rows.Scan(
+			&family.ID,
+			&family.Name,
+			&family.PasswordHash,
+			&family.Password,
+			&family.BabyName,
+			&family.CreatedAt,
+			&family.UpdatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan family: %w", err)
+		}
+		families = append(families, family)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating families: %w", err)
+	}
+
+	return families, nil
+}
+
 // FamilyNameExists checks if a family name already exists (case-insensitive)
 func (s *PostgresStore) FamilyNameExists(ctx context.Context, name string) (bool, error) {
 	var exists bool

--- a/backend/internal/store/postgres/family_test.go
+++ b/backend/internal/store/postgres/family_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/swatkatz/babybaton/backend/internal/domain"
 )
 
 func TestFamilyOperations(t *testing.T) {
@@ -84,6 +85,92 @@ func TestFamilyOperations(t *testing.T) {
 		}
 		
 		t.Logf("✓ Retrieved family by ID: %s", retrieved.ID)
+	})
+
+	// Test GetFamiliesByUserID
+	t.Run("GetFamiliesByUserID", func(t *testing.T) {
+		// Create a user
+		now := time.Now()
+		user := &domain.User{
+			ID:             uuid.New(),
+			SupabaseUserID: "supabase-fam-" + uuid.New().String()[:8],
+			Email:          "fam-test-" + uuid.New().String()[:8] + "@example.com",
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}
+		err := store.CreateUser(ctx, user)
+		if err != nil {
+			t.Fatalf("Failed to create user: %v", err)
+		}
+		t.Cleanup(func() {
+			store.db.ExecContext(ctx, "DELETE FROM users WHERE id = $1", user.ID)
+		})
+
+		// Link the test family's caregiver to the user
+		err = store.LinkCaregiverToUser(ctx, caregiver.ID, user.ID)
+		if err != nil {
+			t.Fatalf("Failed to link caregiver to user: %v", err)
+		}
+
+		// Create a second family with this user
+		family2, _, err := CreateTestFamily(ctx, store)
+		if err != nil {
+			t.Fatalf("Failed to create second family: %v", err)
+		}
+		t.Cleanup(func() {
+			store.DeleteFamily(ctx, family2.ID)
+		})
+
+		// Create a caregiver for user in family2
+		cg2 := &domain.Caregiver{
+			ID:        uuid.New(),
+			FamilyID:  family2.ID,
+			UserID:    &user.ID,
+			Name:      "User in Family2",
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		err = store.CreateCaregiver(ctx, cg2)
+		if err != nil {
+			t.Fatalf("Failed to create caregiver in second family: %v", err)
+		}
+
+		// Now query families by user
+		families, err := store.GetFamiliesByUserID(ctx, user.ID)
+		if err != nil {
+			t.Fatalf("Failed to get families by user: %v", err)
+		}
+		if len(families) != 2 {
+			t.Fatalf("Expected 2 families, got %d", len(families))
+		}
+
+		t.Logf("✓ GetFamiliesByUserID returned %d families", len(families))
+
+		// Test with user that has no families
+		noFamilyUser := &domain.User{
+			ID:             uuid.New(),
+			SupabaseUserID: "supabase-nofam-" + uuid.New().String()[:8],
+			Email:          "nofam-" + uuid.New().String()[:8] + "@example.com",
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}
+		err = store.CreateUser(ctx, noFamilyUser)
+		if err != nil {
+			t.Fatalf("Failed to create user: %v", err)
+		}
+		t.Cleanup(func() {
+			store.db.ExecContext(ctx, "DELETE FROM users WHERE id = $1", noFamilyUser.ID)
+		})
+
+		emptyFamilies, err := store.GetFamiliesByUserID(ctx, noFamilyUser.ID)
+		if err != nil {
+			t.Fatalf("Failed to get families for user with no families: %v", err)
+		}
+		if len(emptyFamilies) != 0 {
+			t.Errorf("Expected 0 families, got %d", len(emptyFamilies))
+		}
+
+		t.Logf("✓ GetFamiliesByUserID correctly returns empty for user with no families")
 	})
 
 	// Test UpdateFamily

--- a/backend/internal/store/store.go
+++ b/backend/internal/store/store.go
@@ -16,6 +16,7 @@ type Store interface {
 	UpdateFamily(ctx context.Context, family *domain.Family) error
 	DeleteFamily(ctx context.Context, id uuid.UUID) error
 	FamilyNameExists(ctx context.Context, name string) (bool, error)
+	GetFamiliesByUserID(ctx context.Context, userID uuid.UUID) ([]*domain.Family, error)
 
 	// User operations
 	CreateUser(ctx context.Context, user *domain.User) error

--- a/schema.graphql
+++ b/schema.graphql
@@ -184,6 +184,7 @@ type Query {
   checkFamilyNameAvailable(name: String!): Boolean!
   getMyFamily: Family
   getMyCaregiver: Caregiver
+  getMyFamilies: [Family!]!
 
   # Care Sessions (automatically scoped to authenticated caregiver's family)
   getRecentCareSessions(limit: Int): [CareSession!]!
@@ -202,7 +203,7 @@ type Mutation {
     password: String!
     babyName: String!
     caregiverName: String!
-    deviceId: String!
+    deviceId: String
     deviceName: String
   ): AuthResult!
 
@@ -210,9 +211,11 @@ type Mutation {
     familyName: String!
     password: String!
     caregiverName: String!
-    deviceId: String!
+    deviceId: String
     deviceName: String
   ): AuthResult!
+
+  linkCaregiverToUser(caregiverId: ID!): Caregiver!
 
   updateBabyName(babyName: String!): Family!
 


### PR DESCRIPTION
## Summary

Closes #25

- Add user-based auth resolvers and migration mutation (#25)

## Test plan

- [ ] Verify the changes address the issue requirements
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)