### PR TITLE
Fix #58: Redesign header with [+] Log Activity and [🗓️] Upcoming icons

### DIFF
--- a/docs/baby_baton_design.md
+++ b/docs/baby_baton_design.md
@@ -1053,7 +1053,7 @@ export const getCaregiverColor = (caregiverId: string) => { ... };
 │  Emma's Baton            [Mo] → │
 ├─────────────────────────────────┤
 │                                 │
-│  🔮 Next Feed Prediction     >  │
+│  🗓️ Next Feed Prediction     >  │
 │  ┌─────────────────────────────┐│
 │  │  ░░░░░ gradient card ░░░░░  ││
 │  │  Upcoming Feed              ││
@@ -1910,7 +1910,7 @@ App Launch → Check auth
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                        HEADER BAR                               │
-│  [+]           Baby's Name Baton              [🔮]             │
+│  [+]           Baby's Name Baton              [🗓️]             │
 │  Log Activity                                 Upcoming          │
 │  (navigates to                                (navigates to     │
 │   LogActivityScreen)                           UpcomingScreen)   │
@@ -1954,7 +1954,7 @@ Main App (Tab Navigator)
 │   ├── Tap Voice Input → VoiceInputModal → ActivityConfirmationModal → save
 │   └── Tap activity icon (Feed/Diaper/Sleep) → Activity form → save
 │
-└── [🔮] Header Button → UpcomingScreen [NEW]
+└── [🗓️] Header Button → UpcomingScreen [NEW]
     └── (leaf screen, no further navigation)
 ```
 
@@ -1964,7 +1964,7 @@ Main App (Tab Navigator)
 
 ```
 ┌──────────────────────────────────┐
-│ [+]    Emma's Baton        [🔮] │
+│ [+]    Emma's Baton        [🗓️] │
 ├──────────────────────────────────┤
 │                                  │
 │  🍼 Last feed: 45m ago          │
@@ -2040,7 +2040,7 @@ Sleep (active — green border + pulsing 💤):
 - Ended sleep: normal border, shows final duration
 
 **What's removed from dashboard:**
-- PredictionCard (replaced by 🔮 Upcoming screen)
+- PredictionCard (replaced by 🗓️ Upcoming screen)
 - Recent Care Sessions section (replaced by History tab)
 - Bottom sticky Voice/Manual bar (replaced by [+] header button)
 
@@ -2078,7 +2078,7 @@ Accessed via [+] button in header. Replaces the old Voice/Manual bottom bar.
 
 #### 18.3.3 Upcoming Screen — NEW
 
-Accessed via [🔮] button in header. Replaces PredictionDetailScreen.
+Accessed via [🗓️] button in header. Replaces PredictionDetailScreen.
 
 ```
 ┌──────────────────────────────────┐
@@ -2116,7 +2116,7 @@ Accessed via [🔮] button in header. Replaces PredictionDetailScreen.
 2. **PREDICTIONS** — AI-generated predictions (feed, sleep). Shows predicted time, reasoning, confidence.
 3. **SCHEDULED** — Calendar events (vaccinations, appointments). Future feature — section is empty/hidden for MVP.
 
-**🔮 Header icon behavior:**
+**🗓️ Header icon behavior:**
 - Shows a red dot badge when any prediction is within ~10 minutes (Needs Attention threshold)
 - Red dot disappears once the predicted time passes or a relevant activity is logged
 - Tapping always opens the full Upcoming screen regardless of badge state
@@ -2391,8 +2391,8 @@ These screens are not modified in the UI refresh. Mocked here for completeness.
 
 | Component | Status | Notes |
 |-----------|--------|-------|
-| `CustomHeader` | **Modified** | Remove avatar. Add [+] left and [🔮] right icons with red dot badge |
-| `PredictionCard` | **Removed** | Replaced by 🔮 Upcoming screen |
+| `CustomHeader` | **Modified** | Remove avatar. Add [+] left and [🗓️] right icons with red dot badge |
+| `PredictionCard` | **Removed** | Replaced by 🗓️ Upcoming screen |
 | `RecentSessionCard` | **Removed** | Replaced by History tab |
 | `CurrentSessionCard` | **Removed** | Replaced by activity grid on dashboard |
 | `ManualEntryModal` | **Modified** | Forms reused in LogActivityScreen; modal wrapper may be removed |
@@ -2483,18 +2483,18 @@ Convert the flat stack navigator to a tab navigator (Home, History, Profile) wit
 
 ---
 
-**Task 2: Redesign CustomHeader with [+] and [🔮] icons**
+**Task 2: Redesign CustomHeader with [+] and [🗓️] icons**
 
-Replace the caregiver avatar in CustomHeader with [+] on the left and [🔮] on the right. The [+] navigates to LogActivityScreen (placeholder for now). The [🔮] navigates to UpcomingScreen (placeholder for now). Add red dot badge support on the 🔮 icon.
+Replace the caregiver avatar in CustomHeader with [+] on the left and [🗓️] on the right. The [+] navigates to LogActivityScreen (placeholder for now). The [🗓️] navigates to UpcomingScreen (placeholder for now). Add red dot badge support on the 🗓️ icon.
 
 *Files to modify:*
-- `frontend/src/components/CustomHeader.tsx` — replace avatar with + and 🔮 icons
+- `frontend/src/components/CustomHeader.tsx` — replace avatar with + and 🗓️ icons
 - `frontend/src/navigation/AppNavigator.tsx` — add LogActivity and Upcoming routes to stack
 
 *Acceptance criteria:*
 - [+] button on left side of header, tappable, navigates to LogActivityScreen (can be empty placeholder)
-- [🔮] icon on right side of header, tappable, navigates to UpcomingScreen (can be empty placeholder)
-- Red dot badge on 🔮 when prediction `minutesUntilFeed` is ≤ 10 (use existing prediction query data)
+- [🗓️] icon on right side of header, tappable, navigates to UpcomingScreen (can be empty placeholder)
+- Red dot badge on 🗓️ when prediction `minutesUntilFeed` is ≤ 10 (use existing prediction query data)
 - Baby name title remains centered
 - Avatar removed from header (settings now accessed via Profile tab)
 - Back button still works on pushed screens
@@ -2596,7 +2596,7 @@ Create the new Log Activity screen with voice input button and activity type ico
 
 **Task 7: Build UpcomingScreen**
 
-Create the Upcoming screen with urgency-based sections. Accessed via [🔮] header button.
+Create the Upcoming screen with urgency-based sections. Accessed via [🗓️] header button.
 
 *Files to create:*
 - `frontend/src/screens/UpcomingScreen.tsx`

--- a/frontend/src/components/CustomHeader.test.tsx
+++ b/frontend/src/components/CustomHeader.test.tsx
@@ -1,0 +1,189 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { StackHeaderProps } from '@react-navigation/stack';
+import { CustomHeader } from './CustomHeader';
+
+// Mock useAuth
+const mockAuthData = {
+  babyName: 'Luna',
+  familyId: 'family-1',
+  caregiverId: 'caregiver-1',
+  caregiverName: 'Mom',
+  familyName: 'Test Family',
+};
+jest.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({
+    authData: mockAuthData,
+  }),
+}));
+
+// Mock safe area insets
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+// Mock Apollo useQuery
+let mockPredictionData: { predictNextFeed: { minutesUntilFeed: number } | null } | undefined;
+jest.mock('@apollo/client/react', () => ({
+  useQuery: () => ({
+    data: mockPredictionData,
+    loading: false,
+    error: undefined,
+  }),
+}));
+
+// Mock lucide icons
+jest.mock('lucide-react-native', () => ({
+  Plus: () => 'Plus',
+  Calendar: () => 'Calendar',
+}));
+
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+const mockCanGoBack = jest.fn();
+
+function createHeaderProps(routeName: string, title?: string): StackHeaderProps {
+  return ({
+    navigation: {
+      navigate: mockNavigate,
+      goBack: mockGoBack,
+      canGoBack: mockCanGoBack,
+      dispatch: jest.fn(),
+      reset: jest.fn(),
+      isFocused: jest.fn(),
+      getParent: jest.fn(),
+      getState: jest.fn(),
+      setOptions: jest.fn(),
+      setParams: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      getId: jest.fn(),
+    } as unknown as StackHeaderProps['navigation'],
+    route: {
+      key: routeName,
+      name: routeName,
+      params: undefined,
+    } as StackHeaderProps['route'],
+    options: {
+      title,
+    } as StackHeaderProps['options'],
+    layout: { width: 375, height: 812 },
+    back: routeName !== 'Dashboard' ? { title: 'Back', href: undefined } : undefined,
+  } as unknown) as StackHeaderProps;
+}
+
+describe('CustomHeader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPredictionData = undefined;
+    mockCanGoBack.mockReturnValue(false);
+  });
+
+  describe('Dashboard screen', () => {
+    it('renders [+] icon on the left', () => {
+      const { getByTestId } = render(
+        <CustomHeader {...createHeaderProps('Dashboard')} />
+      );
+      expect(getByTestId('log-activity-button')).toBeTruthy();
+    });
+
+    it('renders calendar icon on the right', () => {
+      const { getByTestId } = render(
+        <CustomHeader {...createHeaderProps('Dashboard')} />
+      );
+      expect(getByTestId('upcoming-button')).toBeTruthy();
+    });
+
+    it('[+] navigates to LogActivity', () => {
+      const { getByTestId } = render(
+        <CustomHeader {...createHeaderProps('Dashboard')} />
+      );
+      fireEvent.press(getByTestId('log-activity-button'));
+      expect(mockNavigate).toHaveBeenCalledWith('LogActivity');
+    });
+
+    it('calendar navigates to Upcoming', () => {
+      const { getByTestId } = render(
+        <CustomHeader {...createHeaderProps('Dashboard')} />
+      );
+      fireEvent.press(getByTestId('upcoming-button'));
+      expect(mockNavigate).toHaveBeenCalledWith('Upcoming');
+    });
+
+    it('shows baby name centered', () => {
+      const { getByText } = render(
+        <CustomHeader {...createHeaderProps('Dashboard')} />
+      );
+      expect(getByText(/Luna's Baton/)).toBeTruthy();
+    });
+
+    it('does not render caregiver avatar', () => {
+      const { queryByTestId } = render(
+        <CustomHeader {...createHeaderProps('Dashboard')} />
+      );
+      expect(queryByTestId('caregiver-avatar')).toBeNull();
+    });
+  });
+
+  describe('non-Dashboard screen', () => {
+    it('shows back button and no action icons', () => {
+      mockCanGoBack.mockReturnValue(true);
+      const { queryByTestId } = render(
+        <CustomHeader {...createHeaderProps('PredictionDetail', 'Prediction Details')} />
+      );
+      expect(queryByTestId('log-activity-button')).toBeNull();
+      expect(queryByTestId('upcoming-button')).toBeNull();
+    });
+
+    it('back button calls goBack', () => {
+      mockCanGoBack.mockReturnValue(true);
+      const { getByText } = render(
+        <CustomHeader {...createHeaderProps('PredictionDetail', 'Prediction Details')} />
+      );
+      fireEvent.press(getByText('←'));
+      expect(mockGoBack).toHaveBeenCalled();
+    });
+  });
+
+  describe('red dot badge', () => {
+    it('shows red dot when minutesUntilFeed <= 10', () => {
+      mockPredictionData = { predictNextFeed: { minutesUntilFeed: 5 } };
+      const { getByTestId } = render(
+        <CustomHeader {...createHeaderProps('Dashboard')} />
+      );
+      expect(getByTestId('upcoming-badge')).toBeTruthy();
+    });
+
+    it('shows red dot when minutesUntilFeed is 0', () => {
+      mockPredictionData = { predictNextFeed: { minutesUntilFeed: 0 } };
+      const { getByTestId } = render(
+        <CustomHeader {...createHeaderProps('Dashboard')} />
+      );
+      expect(getByTestId('upcoming-badge')).toBeTruthy();
+    });
+
+    it('shows red dot when minutesUntilFeed is negative', () => {
+      mockPredictionData = { predictNextFeed: { minutesUntilFeed: -3 } };
+      const { getByTestId } = render(
+        <CustomHeader {...createHeaderProps('Dashboard')} />
+      );
+      expect(getByTestId('upcoming-badge')).toBeTruthy();
+    });
+
+    it('hides red dot when minutesUntilFeed > 10', () => {
+      mockPredictionData = { predictNextFeed: { minutesUntilFeed: 30 } };
+      const { queryByTestId } = render(
+        <CustomHeader {...createHeaderProps('Dashboard')} />
+      );
+      expect(queryByTestId('upcoming-badge')).toBeNull();
+    });
+
+    it('hides red dot when no prediction data', () => {
+      mockPredictionData = undefined;
+      const { queryByTestId } = render(
+        <CustomHeader {...createHeaderProps('Dashboard')} />
+      );
+      expect(queryByTestId('upcoming-badge')).toBeNull();
+    });
+  });
+});

--- a/frontend/src/components/CustomHeader.tsx
+++ b/frontend/src/components/CustomHeader.tsx
@@ -2,19 +2,42 @@ import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { StackHeaderProps } from '@react-navigation/stack';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useQuery } from '@apollo/client/react';
+import { Plus, Calendar } from 'lucide-react-native';
 import { useAuth } from '../hooks/useAuth';
 import { spacing } from '../theme/spacing';
+import { colors } from '../theme/colors';
+import { GetPredictionDocument } from '../types/__generated__/graphql';
+
+const ICON_SIZE = 24;
 
 export function CustomHeader({ options, route, navigation }: StackHeaderProps) {
   const { authData } = useAuth();
   const insets = useSafeAreaInsets();
 
+  const isDashboard = route.name === 'Dashboard';
+
+  const { data: predictionData } = useQuery(GetPredictionDocument, {
+    skip: !isDashboard,
+  });
+
+  const minutesUntilFeed = predictionData?.predictNextFeed?.minutesUntilFeed;
+  const showBadge = typeof minutesUntilFeed === 'number' && minutesUntilFeed <= 10;
+
   const handleBackPress = () => {
     navigation.goBack();
   };
 
+  const handleLogActivity = () => {
+    navigation.navigate('LogActivity');
+  };
+
+  const handleUpcoming = () => {
+    navigation.navigate('Upcoming');
+  };
+
   // Get the title from route options or use baby name
-  const showBabyName = route.name === 'Dashboard';
+  const showBabyName = isDashboard;
   const canGoBack = navigation.canGoBack();
   const title =
     showBabyName && authData?.babyName
@@ -24,23 +47,51 @@ export function CustomHeader({ options, route, navigation }: StackHeaderProps) {
   return (
     <View style={[styles.header, { paddingTop: insets.top }]}>
       <View style={styles.content}>
-        {/* Back Button */}
-        {canGoBack && (
-          <TouchableOpacity
-            onPress={handleBackPress}
-            style={styles.backButton}
-            activeOpacity={0.7}
-          >
-            <Text style={styles.backButtonText}>←</Text>
-          </TouchableOpacity>
-        )}
+        {/* Left side: [+] on Dashboard, back button on other screens */}
+        <View style={styles.sideContainer}>
+          {isDashboard ? (
+            <TouchableOpacity
+              onPress={handleLogActivity}
+              style={styles.iconButton}
+              activeOpacity={0.7}
+              testID="log-activity-button"
+              accessibilityLabel="Log Activity"
+            >
+              <Plus size={ICON_SIZE} color="#FFFFFF" />
+            </TouchableOpacity>
+          ) : canGoBack ? (
+            <TouchableOpacity
+              onPress={handleBackPress}
+              style={styles.iconButton}
+              activeOpacity={0.7}
+            >
+              <Text style={styles.backButtonText}>←</Text>
+            </TouchableOpacity>
+          ) : null}
+        </View>
 
-        {/* Title */}
+        {/* Title (centered) */}
         <View style={styles.titleContainer}>
           <Text style={styles.title}>
             {showBabyName && '🍼  '}
             {title}
           </Text>
+        </View>
+
+        {/* Right side: [🗓️] on Dashboard */}
+        <View style={styles.sideContainer}>
+          {isDashboard && (
+            <TouchableOpacity
+              onPress={handleUpcoming}
+              style={styles.iconButton}
+              activeOpacity={0.7}
+              testID="upcoming-button"
+              accessibilityLabel="Upcoming"
+            >
+              <Calendar size={ICON_SIZE} color="#FFFFFF" />
+              {showBadge && <View style={styles.badge} testID="upcoming-badge" />}
+            </TouchableOpacity>
+          )}
         </View>
       </View>
     </View>
@@ -63,9 +114,17 @@ const styles = StyleSheet.create({
     height: 56,
     paddingHorizontal: spacing.md,
   },
-  backButton: {
-    marginRight: spacing.sm,
-    padding: spacing.xs,
+  sideContainer: {
+    width: 44,
+    height: 44,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  iconButton: {
+    width: 44,
+    height: 44,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   backButtonText: {
     fontSize: 28,
@@ -74,11 +133,22 @@ const styles = StyleSheet.create({
   },
   titleContainer: {
     flex: 1,
+    alignItems: 'center',
     justifyContent: 'center',
   },
   title: {
     fontSize: 20,
     fontWeight: 'bold' as const,
     color: '#FFFFFF',
+    textAlign: 'center',
+  },
+  badge: {
+    position: 'absolute',
+    top: 8,
+    right: 6,
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: colors.error,
   },
 });

--- a/frontend/src/navigation/MainTabNavigator.tsx
+++ b/frontend/src/navigation/MainTabNavigator.tsx
@@ -6,6 +6,8 @@ import { DashboardScreen } from '../screens/DashboardScreen';
 import { PredictionDetailScreen } from '../screens/PredictionDetailScreen';
 import { CurrentSessionDetailScreen } from '../screens/CurrentSessionDetailScreen';
 import { SessionDetailScreen } from '../screens/SessionDetailScreen';
+import { LogActivityScreen } from '../screens/LogActivityScreen';
+import { UpcomingScreen } from '../screens/UpcomingScreen';
 import { HistoryScreen } from '../screens/HistoryScreen';
 import { SettingsScreen } from '../screens/SettingsScreen';
 import { CustomHeader } from '../components/CustomHeader';
@@ -19,6 +21,8 @@ export type HomeStackParamList = {
   };
   CurrentSessionDetail: undefined;
   SessionDetail: { sessionId: string };
+  LogActivity: undefined;
+  Upcoming: undefined;
 };
 
 export type MainTabParamList = {
@@ -61,6 +65,22 @@ function HomeStackNavigator() {
         component={SessionDetailScreen}
         options={{
           title: 'Session Details',
+          header: (props) => <CustomHeader {...props} />,
+        }}
+      />
+      <HomeStack.Screen
+        name="LogActivity"
+        component={LogActivityScreen}
+        options={{
+          title: 'Log Activity',
+          header: (props) => <CustomHeader {...props} />,
+        }}
+      />
+      <HomeStack.Screen
+        name="Upcoming"
+        component={UpcomingScreen}
+        options={{
+          title: 'Upcoming',
           header: (props) => <CustomHeader {...props} />,
         }}
       />

--- a/frontend/src/screens/LogActivityScreen.test.tsx
+++ b/frontend/src/screens/LogActivityScreen.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { LogActivityScreen } from './LogActivityScreen';
+
+describe('LogActivityScreen', () => {
+  it('renders placeholder text', () => {
+    const { getByText } = render(<LogActivityScreen />);
+    expect(getByText('Log Activity coming soon')).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/LogActivityScreen.tsx
+++ b/frontend/src/screens/LogActivityScreen.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { colors } from '../theme/colors';
+
+export function LogActivityScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Log Activity coming soon</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  text: {
+    fontSize: 18,
+    color: colors.textSecondary,
+  },
+});

--- a/frontend/src/screens/UpcomingScreen.test.tsx
+++ b/frontend/src/screens/UpcomingScreen.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { UpcomingScreen } from './UpcomingScreen';
+
+describe('UpcomingScreen', () => {
+  it('renders placeholder text', () => {
+    const { getByText } = render(<UpcomingScreen />);
+    expect(getByText('Upcoming coming soon')).toBeTruthy();
+  });
+});

--- a/frontend/src/screens/UpcomingScreen.tsx
+++ b/frontend/src/screens/UpcomingScreen.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { colors } from '../theme/colors';
+
+export function UpcomingScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Upcoming coming soon</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  text: {
+    fontSize: 18,
+    color: colors.textSecondary,
+  },
+});


### PR DESCRIPTION
## Summary

Closes #58

- Redesign header with [+] Log Activity and [🗓️] Upcoming icons (#58)

## Test plan

- [ ] Verify the changes address the issue requirements
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)