### PR TITLE
Fix #63: Build Log Activity screen with voice input and activity type grid

### DIFF
--- a/frontend/src/components/ActivityConfirmationModal.tsx
+++ b/frontend/src/components/ActivityConfirmationModal.tsx
@@ -13,7 +13,7 @@ import { Utensils, Droplets, Moon } from 'lucide-react-native';
 import { colors } from '../theme/colors';
 import { spacing } from '../theme/spacing';
 
-interface ParsedActivity {
+export interface ParsedActivity {
   activityType: string;
   feedDetails?: {
     startTime: string;

--- a/frontend/src/components/ManualEntryModal.test.tsx
+++ b/frontend/src/components/ManualEntryModal.test.tsx
@@ -330,4 +330,52 @@ describe('ManualEntryModal', () => {
       expect(getByText('Pee')).toBeTruthy();
     });
   });
+
+  describe('initialActivityType prop', () => {
+    it('should render Feed form directly when initialActivityType="FEED"', () => {
+      const { getByText, queryByText } = render(
+        <ManualEntryModal {...baseProps} initialActivityType="FEED" />
+      );
+      expect(queryByText('What would you like to log?')).toBeNull();
+      expect(getByText('Amount (ml)')).toBeTruthy();
+      expect(getByText('Feed Type')).toBeTruthy();
+      expect(getByText('Save Activity')).toBeTruthy();
+    });
+
+    it('should render Diaper form directly when initialActivityType="DIAPER"', () => {
+      const { getByText, queryByText } = render(
+        <ManualEntryModal {...baseProps} initialActivityType="DIAPER" />
+      );
+      expect(queryByText('What would you like to log?')).toBeNull();
+      expect(getByText('Pee')).toBeTruthy();
+      expect(getByText('Poop')).toBeTruthy();
+    });
+
+    it('should render Sleep form directly when initialActivityType="SLEEP"', () => {
+      const { getByText, queryByText } = render(
+        <ManualEntryModal {...baseProps} initialActivityType="SLEEP" />
+      );
+      expect(queryByText('What would you like to log?')).toBeNull();
+      expect(getByText('Start Time')).toBeTruthy();
+      expect(getByText('Set End Time')).toBeTruthy();
+    });
+
+    it('should still show type selector when initialActivityType is not provided', () => {
+      const { getByText } = render(<ManualEntryModal {...baseProps} />);
+      expect(getByText('What would you like to log?')).toBeTruthy();
+    });
+
+    it('should save correctly with pre-selected type', () => {
+      const { getByText, getByPlaceholderText } = render(
+        <ManualEntryModal {...baseProps} initialActivityType="FEED" />
+      );
+      fireEvent.changeText(getByPlaceholderText('e.g., 120'), '150');
+      fireEvent.press(getByText('Save Activity'));
+
+      expect(baseProps.onSave).toHaveBeenCalledTimes(1);
+      const savedActivities = baseProps.onSave.mock.calls[0][0];
+      expect(savedActivities[0].activityType).toBe(ActivityType.Feed);
+      expect(savedActivities[0].feedDetails.amountMl).toBe(150);
+    });
+  });
 });

--- a/frontend/src/components/ManualEntryModal.tsx
+++ b/frontend/src/components/ManualEntryModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -17,13 +17,14 @@ import { colors } from '../theme/colors';
 import { spacing, typography, layout } from '../theme/spacing';
 import { ActivityType, FeedType, SolidsUnit, ActivityInput } from '../types/__generated__/graphql';
 
-type SelectedActivityType = 'FEED' | 'DIAPER' | 'SLEEP';
+export type SelectedActivityType = 'FEED' | 'DIAPER' | 'SLEEP';
 
 interface ManualEntryModalProps {
   visible: boolean;
   onClose: () => void;
   onSave: (activities: ActivityInput[]) => void;
   saving: boolean;
+  initialActivityType?: SelectedActivityType;
 }
 
 export function ManualEntryModal({
@@ -31,8 +32,15 @@ export function ManualEntryModal({
   onClose,
   onSave,
   saving,
+  initialActivityType,
 }: ManualEntryModalProps) {
-  const [selectedType, setSelectedType] = useState<SelectedActivityType | null>(null);
+  const [selectedType, setSelectedType] = useState<SelectedActivityType | null>(initialActivityType ?? null);
+
+  useEffect(() => {
+    if (visible) {
+      setSelectedType(initialActivityType ?? null);
+    }
+  }, [visible, initialActivityType]);
 
   // Feed state
   const [feedTime, setFeedTime] = useState(new Date());
@@ -59,7 +67,7 @@ export function ManualEntryModal({
   const [showPicker, setShowPicker] = useState<string | null>(null);
 
   const resetForm = () => {
-    setSelectedType(null);
+    setSelectedType(initialActivityType ?? null);
     setFeedTime(new Date());
     setFeedAmount('');
     setFeedType(FeedType.Formula);
@@ -542,7 +550,7 @@ export function ManualEntryModal({
             style={styles.scrollContent}
             keyboardShouldPersistTaps="handled"
           >
-            {renderActivityTypeSelector()}
+            {!initialActivityType && renderActivityTypeSelector()}
             {renderForm()}
           </ScrollView>
 

--- a/frontend/src/navigation/MainTabNavigator.test.tsx
+++ b/frontend/src/navigation/MainTabNavigator.test.tsx
@@ -63,6 +63,12 @@ jest.mock('../screens/CurrentSessionDetailScreen', () => ({
 jest.mock('../screens/SessionDetailScreen', () => ({
   SessionDetailScreen: () => null,
 }));
+jest.mock('../screens/LogActivityScreen', () => ({
+  LogActivityScreen: () => null,
+}));
+jest.mock('../screens/UpcomingScreen', () => ({
+  UpcomingScreen: () => null,
+}));
 jest.mock('../components/CustomHeader', () => ({
   CustomHeader: () => null,
 }));

--- a/frontend/src/screens/LogActivityScreen.test.tsx
+++ b/frontend/src/screens/LogActivityScreen.test.tsx
@@ -1,10 +1,299 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { Alert } from 'react-native';
 import { LogActivityScreen } from './LogActivityScreen';
 
+// Mock navigation
+const mockGoBack = jest.fn();
+const mockNavigation = {
+  goBack: mockGoBack,
+  navigate: jest.fn(),
+  dispatch: jest.fn(),
+  reset: jest.fn(),
+  isFocused: jest.fn(),
+  canGoBack: jest.fn().mockReturnValue(true),
+  getParent: jest.fn(),
+  getState: jest.fn(),
+  setOptions: jest.fn(),
+  setParams: jest.fn(),
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+  getId: jest.fn(),
+};
+
+const mockRoute = {
+  key: 'LogActivity',
+  name: 'LogActivity' as const,
+  params: undefined,
+};
+
+// Mock useMutation
+const mockAddActivities = jest.fn();
+jest.mock('@apollo/client/react', () => ({
+  useMutation: () => [mockAddActivities],
+}));
+
+// Mock lucide icons
+jest.mock('lucide-react-native', () => ({
+  Utensils: () => 'Utensils',
+  Droplets: () => 'Droplets',
+  Moon: () => 'Moon',
+  Pill: () => 'Pill',
+  Ruler: () => 'Ruler',
+}));
+
+// Mock VoiceInputModal
+let mockVoiceProps: Record<string, unknown> = {};
+jest.mock('../components/VoiceInputModal', () => ({
+  VoiceInputModal: (mockProps: any) => {
+    mockVoiceProps = mockProps;
+    if (!mockProps.visible) return null;
+    const RN = require('react-native');
+    return (
+      <RN.View testID="voice-input-modal">
+        <RN.TouchableOpacity testID="voice-parse-success" onPress={() => {
+          mockProps.onActivitiesParsed({
+            rawText: 'Fed baby 120ml',
+            parsedActivities: [{ activityType: 'FEED', feedDetails: { startTime: '2025-01-01T12:00:00Z', amountMl: 120, feedType: 'FORMULA' } }],
+            errors: [],
+          });
+        }}>
+          <RN.Text>Simulate Parse</RN.Text>
+        </RN.TouchableOpacity>
+        <RN.TouchableOpacity testID="voice-switch-manual" onPress={() => {
+          if (mockProps.onSwitchToManualEntry) mockProps.onSwitchToManualEntry();
+        }}>
+          <RN.Text>Switch to Manual</RN.Text>
+        </RN.TouchableOpacity>
+      </RN.View>
+    );
+  },
+}));
+
+// Mock ActivityConfirmationModal
+let mockConfirmProps: Record<string, unknown> = {};
+jest.mock('../components/ActivityConfirmationModal', () => ({
+  ActivityConfirmationModal: (mockProps: any) => {
+    mockConfirmProps = mockProps;
+    if (!mockProps.visible) return null;
+    const RN = require('react-native');
+    return (
+      <RN.View testID="confirmation-modal">
+        <RN.TouchableOpacity testID="confirm-save" onPress={() => mockProps.onConfirm()}>
+          <RN.Text>Confirm</RN.Text>
+        </RN.TouchableOpacity>
+        <RN.TouchableOpacity testID="confirm-rerecord" onPress={() => mockProps.onReRecord()}>
+          <RN.Text>Re-record</RN.Text>
+        </RN.TouchableOpacity>
+      </RN.View>
+    );
+  },
+}));
+
+// Mock ManualEntryModal
+let mockManualProps: Record<string, unknown> = {};
+jest.mock('../components/ManualEntryModal', () => ({
+  ManualEntryModal: (mockProps: any) => {
+    mockManualProps = mockProps;
+    if (!mockProps.visible) return null;
+    const RN = require('react-native');
+    return (
+      <RN.View testID="manual-entry-modal">
+        <RN.Text testID="manual-initial-type">{String(mockProps.initialActivityType ?? 'none')}</RN.Text>
+        <RN.TouchableOpacity testID="manual-save" onPress={() => {
+          mockProps.onSave([{
+            activityType: 'FEED',
+            feedDetails: { startTime: '2025-01-01T12:00:00Z', amountMl: 120, feedType: 'FORMULA' },
+          }]);
+        }}>
+          <RN.Text>Save</RN.Text>
+        </RN.TouchableOpacity>
+      </RN.View>
+    );
+  },
+}));
+
+// Mock DateTimePicker
+jest.mock('@react-native-community/datetimepicker', () => {
+  const RN = require('react-native');
+  return { __esModule: true, default: () => <RN.View /> };
+});
+
 describe('LogActivityScreen', () => {
-  it('renders placeholder text', () => {
-    const { getByText } = render(<LogActivityScreen />);
-    expect(getByText('Log Activity coming soon')).toBeTruthy();
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockVoiceProps = {};
+    mockConfirmProps = {};
+    mockManualProps = {};
+    mockAddActivities.mockResolvedValue({ data: { addActivities: { id: '1' } } });
+  });
+
+  describe('rendering', () => {
+    it('renders voice input section with mic button', () => {
+      const { getByTestId } = render(
+        <LogActivityScreen navigation={mockNavigation as any} route={mockRoute as any} />
+      );
+      expect(getByTestId('mic-button')).toBeTruthy();
+    });
+
+    it('renders "Tap the microphone to start" text', () => {
+      const { getByText } = render(
+        <LogActivityScreen navigation={mockNavigation as any} route={mockRoute as any} />
+      );
+      expect(getByText('Tap the microphone to start')).toBeTruthy();
+    });
+
+    it('renders example phrases', () => {
+      const { getByText } = render(
+        <LogActivityScreen navigation={mockNavigation as any} route={mockRoute as any} />
+      );
+      expect(getByText(/Fed baby 120ml at 3pm/)).toBeTruthy();
+      expect(getByText(/Changed diaper at 4pm, had poop/)).toBeTruthy();
+      expect(getByText(/Baby slept from 2pm to 4pm/)).toBeTruthy();
+    });
+
+    it('renders Feed, Diaper, Sleep activity cards', () => {
+      const { getByTestId } = render(
+        <LogActivityScreen navigation={mockNavigation as any} route={mockRoute as any} />
+      );
+      expect(getByTestId('activity-card-feed')).toBeTruthy();
+      expect(getByTestId('activity-card-diaper')).toBeTruthy();
+      expect(getByTestId('activity-card-sleep')).toBeTruthy();
+    });
+
+    it('renders Meds and Growth as "Coming soon"', () => {
+      const { getByTestId, getAllByText } = render(
+        <LogActivityScreen navigation={mockNavigation as any} route={mockRoute as any} />
+      );
+      expect(getByTestId('activity-card-meds')).toBeTruthy();
+      expect(getByTestId('activity-card-growth')).toBeTruthy();
+      expect(getAllByText('Coming soon')).toHaveLength(2);
+    });
+
+    it('renders "Or tap to log:" section title', () => {
+      const { getByText } = render(
+        <LogActivityScreen navigation={mockNavigation as any} route={mockRoute as any} />
+      );
+      expect(getByText('Or tap to log:')).toBeTruthy();
+    });
+  });
+
+  describe('voice input flow', () => {
+    it('opens VoiceInputModal when mic button tapped', () => {
+      const { getByTestId } = render(
+        <LogActivityScreen navigation={mockNavigation as any} route={mockRoute as any} />
+      );
+      fireEvent.press(getByTestId('mic-button'));
+      expect(getByTestId('voice-input-modal')).toBeTruthy();
+    });
+
+    it('opens ActivityConfirmationModal after voice parsing succeeds', () => {
+      const { getByTestId } = render(
+        <LogActivityScreen navigation={mockNavigation as any} route={mockRoute as any} />
+      );
+      fireEvent.press(getByTestId('mic-button'));
+      fireEvent.press(getByTestId('voice-parse-success'));
+      expect(getByTestId('confirmation-modal')).toBeTruthy();
+    });
+
+    it('calls addActivities and goBack on voice confirm', async () => {
+      const { getByTestId } = render(
+        <LogActivityScreen navigation={mockNavigation as any} route={mockRoute as any} />
+      );
+      fireEvent.press(getByTestId('mic-button'));
+      fireEvent.press(getByTestId('voice-parse-success'));
+      fireEvent.press(getByTestId('confirm-save'));
+
+      await waitFor(() => {
+        expect(mockAddActivities).toHaveBeenCalled();
+        expect(mockGoBack).toHaveBeenCalled();
+      });
+    });
+
+    it('shows alert on save error instead of navigating back', async () => {
+      mockAddActivities.mockRejectedValueOnce(new Error('Network error'));
+      jest.spyOn(Alert, 'alert');
+
+      const { getByTestId } = render(
+        <LogActivityScreen navigation={mockNavigation as any} route={mockRoute as any} />
+      );
+      fireEvent.press(getByTestId('mic-button'));
+      fireEvent.press(getByTestId('voice-parse-success'));
+      fireEvent.press(getByTestId('confirm-save'));
+
+      await waitFor(() => {
+        expect(Alert.alert).toHaveBeenCalledWith('Error', 'Failed to save activities. Please try again.');
+        expect(mockGoBack).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('manual entry flow', () => {
+    it('opens ManualEntryModal with initialActivityType=FEED when Feed tapped', () => {
+      const { getByTestId } = render(
+        <LogActivityScreen navigation={mockNavigation as any} route={mockRoute as any} />
+      );
+      fireEvent.press(getByTestId('activity-card-feed'));
+      expect(getByTestId('manual-entry-modal')).toBeTruthy();
+      expect(getByTestId('manual-initial-type').props.children).toBe('FEED');
+    });
+
+    it('opens ManualEntryModal with initialActivityType=DIAPER when Diaper tapped', () => {
+      const { getByTestId } = render(
+        <LogActivityScreen navigation={mockNavigation as any} route={mockRoute as any} />
+      );
+      fireEvent.press(getByTestId('activity-card-diaper'));
+      expect(getByTestId('manual-entry-modal')).toBeTruthy();
+      expect(getByTestId('manual-initial-type').props.children).toBe('DIAPER');
+    });
+
+    it('opens ManualEntryModal with initialActivityType=SLEEP when Sleep tapped', () => {
+      const { getByTestId } = render(
+        <LogActivityScreen navigation={mockNavigation as any} route={mockRoute as any} />
+      );
+      fireEvent.press(getByTestId('activity-card-sleep'));
+      expect(getByTestId('manual-entry-modal')).toBeTruthy();
+      expect(getByTestId('manual-initial-type').props.children).toBe('SLEEP');
+    });
+
+    it('does NOT open modal when Meds tapped (disabled)', () => {
+      const { getByTestId, queryByTestId } = render(
+        <LogActivityScreen navigation={mockNavigation as any} route={mockRoute as any} />
+      );
+      fireEvent.press(getByTestId('activity-card-meds'));
+      expect(queryByTestId('manual-entry-modal')).toBeNull();
+    });
+
+    it('does NOT open modal when Growth tapped (disabled)', () => {
+      const { getByTestId, queryByTestId } = render(
+        <LogActivityScreen navigation={mockNavigation as any} route={mockRoute as any} />
+      );
+      fireEvent.press(getByTestId('activity-card-growth'));
+      expect(queryByTestId('manual-entry-modal')).toBeNull();
+    });
+
+    it('calls addActivities and goBack on manual save', async () => {
+      const { getByTestId } = render(
+        <LogActivityScreen navigation={mockNavigation as any} route={mockRoute as any} />
+      );
+      fireEvent.press(getByTestId('activity-card-feed'));
+      fireEvent.press(getByTestId('manual-save'));
+
+      await waitFor(() => {
+        expect(mockAddActivities).toHaveBeenCalled();
+        expect(mockGoBack).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('voice to manual fallback', () => {
+    it('switches to ManualEntryModal when voice input fails and user taps switch', () => {
+      const { getByTestId } = render(
+        <LogActivityScreen navigation={mockNavigation as any} route={mockRoute as any} />
+      );
+      fireEvent.press(getByTestId('mic-button'));
+      fireEvent.press(getByTestId('voice-switch-manual'));
+      expect(getByTestId('manual-entry-modal')).toBeTruthy();
+    });
   });
 });

--- a/frontend/src/screens/LogActivityScreen.tsx
+++ b/frontend/src/screens/LogActivityScreen.tsx
@@ -1,11 +1,259 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  Alert,
+} from 'react-native';
+import { useMutation } from '@apollo/client/react';
+import { StackScreenProps } from '@react-navigation/stack';
+import { Utensils, Droplets, Moon, Pill, Ruler } from 'lucide-react-native';
+import { VoiceInputModal } from '../components/VoiceInputModal';
+import { ManualEntryModal, SelectedActivityType } from '../components/ManualEntryModal';
+import { ActivityConfirmationModal, ParsedActivity } from '../components/ActivityConfirmationModal';
 import { colors } from '../theme/colors';
+import { spacing, typography, layout } from '../theme/spacing';
+import { HomeStackParamList } from '../navigation/MainTabNavigator';
+import {
+  AddActivitiesDocument,
+  GetCurrentSessionDocument,
+  GetBabyStatusDocument,
+  ActivityInput,
+} from '../types/__generated__/graphql';
 
-export function LogActivityScreen() {
+type Props = StackScreenProps<HomeStackParamList, 'LogActivity'>;
+
+interface ActivityTypeCard {
+  type: SelectedActivityType;
+  label: string;
+  emoji: string;
+  icon: React.ReactElement;
+  color: string;
+  enabled: boolean;
+}
+
+const ACTIVITY_TYPES: (ActivityTypeCard | { label: string; emoji: string; icon: React.ReactElement; color: string; enabled: false })[] = [
+  {
+    type: 'FEED' as SelectedActivityType,
+    label: 'Feed',
+    emoji: '\uD83C\uDF7C',
+    icon: <Utensils size={28} color={colors.feed} />,
+    color: colors.feed,
+    enabled: true,
+  },
+  {
+    type: 'DIAPER' as SelectedActivityType,
+    label: 'Diaper',
+    emoji: '\uD83D\uDCA9',
+    icon: <Droplets size={28} color={colors.diaper} />,
+    color: colors.diaper,
+    enabled: true,
+  },
+  {
+    type: 'SLEEP' as SelectedActivityType,
+    label: 'Sleep',
+    emoji: '\uD83D\uDE34',
+    icon: <Moon size={28} color={colors.sleep} />,
+    color: colors.sleep,
+    enabled: true,
+  },
+  {
+    label: 'Meds',
+    emoji: '\uD83D\uDC8A',
+    icon: <Pill size={28} color={colors.textLight} />,
+    color: colors.textLight,
+    enabled: false,
+  },
+  {
+    label: 'Growth',
+    emoji: '\uD83D\uDCCF',
+    icon: <Ruler size={28} color={colors.textLight} />,
+    color: colors.textLight,
+    enabled: false,
+  },
+];
+
+export function LogActivityScreen({ navigation }: Props) {
+  const [voiceModalVisible, setVoiceModalVisible] = useState(false);
+  const [manualEntryVisible, setManualEntryVisible] = useState(false);
+  const [confirmationModalVisible, setConfirmationModalVisible] = useState(false);
+  const [parsedResult, setParsedResult] = useState<{
+    rawText: string;
+    parsedActivities: ParsedActivity[];
+    errors: string[];
+  } | null>(null);
+  const [manualActivityType, setManualActivityType] = useState<SelectedActivityType | undefined>(undefined);
+  const [saving, setSaving] = useState(false);
+
+  const [addActivities] = useMutation(AddActivitiesDocument, {
+    refetchQueries: [
+      { query: GetCurrentSessionDocument },
+      { query: GetBabyStatusDocument },
+    ],
+  });
+
+  const handleVoiceParsed = (result: {
+    rawText: string;
+    parsedActivities: ParsedActivity[];
+    errors: string[];
+  }) => {
+    setParsedResult(result);
+    setVoiceModalVisible(false);
+    setConfirmationModalVisible(true);
+  };
+
+  const handleVoiceConfirm = async () => {
+    if (!parsedResult?.parsedActivities?.length) return;
+
+    setSaving(true);
+    try {
+      await addActivities({
+        variables: {
+          activities: parsedResult.parsedActivities.map((a) => ({
+            activityType: a.activityType as ActivityInput['activityType'],
+            feedDetails: a.feedDetails as ActivityInput['feedDetails'],
+            diaperDetails: a.diaperDetails as ActivityInput['diaperDetails'],
+            sleepDetails: a.sleepDetails as ActivityInput['sleepDetails'],
+          })),
+        },
+      });
+      setConfirmationModalVisible(false);
+      setParsedResult(null);
+      navigation.goBack();
+    } catch (error) {
+      Alert.alert('Error', 'Failed to save activities. Please try again.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleVoiceReRecord = () => {
+    setConfirmationModalVisible(false);
+    setParsedResult(null);
+    setVoiceModalVisible(true);
+  };
+
+  const handleSwitchToManualEntry = () => {
+    setVoiceModalVisible(false);
+    setManualActivityType(undefined);
+    setManualEntryVisible(true);
+  };
+
+  const handleActivityTypePress = (type: SelectedActivityType) => {
+    setManualActivityType(type);
+    setManualEntryVisible(true);
+  };
+
+  const handleManualSave = async (activities: ActivityInput[]) => {
+    setSaving(true);
+    try {
+      await addActivities({
+        variables: { activities },
+      });
+      setManualEntryVisible(false);
+      setManualActivityType(undefined);
+      navigation.goBack();
+    } catch (error) {
+      Alert.alert('Error', 'Failed to save activity. Please try again.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleManualClose = () => {
+    setManualEntryVisible(false);
+    setManualActivityType(undefined);
+  };
+
   return (
     <View style={styles.container}>
-      <Text style={styles.text}>Log Activity coming soon</Text>
+      <ScrollView contentContainerStyle={styles.content}>
+        {/* Voice Input Section */}
+        <View style={styles.voiceSection}>
+          <TouchableOpacity
+            style={styles.micButton}
+            onPress={() => setVoiceModalVisible(true)}
+            activeOpacity={0.7}
+            testID="mic-button"
+          >
+            <Text style={styles.micEmoji}>{'\uD83C\uDFA4'}</Text>
+          </TouchableOpacity>
+          <Text style={styles.voiceTitle}>Tap the microphone to start</Text>
+          <View style={styles.examplesContainer}>
+            <Text style={styles.examplesTitle}>Examples:</Text>
+            <Text style={styles.exampleText}>{'\u2022'} &quot;Fed baby 120ml at 3pm&quot;</Text>
+            <Text style={styles.exampleText}>{'\u2022'} &quot;Changed diaper at 4pm, had poop&quot;</Text>
+            <Text style={styles.exampleText}>{'\u2022'} &quot;Baby slept from 2pm to 4pm&quot;</Text>
+          </View>
+        </View>
+
+        {/* Activity Type Grid */}
+        <Text style={styles.gridTitle}>Or tap to log:</Text>
+        <View style={styles.activityGrid}>
+          {ACTIVITY_TYPES.map((item) => (
+            <TouchableOpacity
+              key={item.label}
+              style={[
+                styles.activityCard,
+                !item.enabled && styles.activityCardDisabled,
+              ]}
+              onPress={() => {
+                if (item.enabled && 'type' in item) {
+                  handleActivityTypePress(item.type);
+                }
+              }}
+              disabled={!item.enabled}
+              activeOpacity={0.7}
+              testID={`activity-card-${item.label.toLowerCase()}`}
+            >
+              <View style={[styles.activityIconContainer, { backgroundColor: `${item.color}20` }]}>
+                {item.icon}
+              </View>
+              <Text style={[styles.activityCardLabel, !item.enabled && styles.activityCardLabelDisabled]}>
+                {item.label}
+              </Text>
+              {!item.enabled && (
+                <Text style={styles.comingSoonText}>Coming soon</Text>
+              )}
+            </TouchableOpacity>
+          ))}
+        </View>
+      </ScrollView>
+
+      {/* Voice Input Modal */}
+      <VoiceInputModal
+        visible={voiceModalVisible}
+        onClose={() => setVoiceModalVisible(false)}
+        onActivitiesParsed={handleVoiceParsed}
+        onSwitchToManualEntry={handleSwitchToManualEntry}
+      />
+
+      {/* Activity Confirmation Modal (after voice parsing) */}
+      {parsedResult && (
+        <ActivityConfirmationModal
+          visible={confirmationModalVisible}
+          rawText={parsedResult.rawText}
+          parsedActivities={parsedResult.parsedActivities}
+          errors={parsedResult.errors}
+          onConfirm={handleVoiceConfirm}
+          onReRecord={handleVoiceReRecord}
+          onCancel={() => {
+            setConfirmationModalVisible(false);
+            setParsedResult(null);
+          }}
+        />
+      )}
+
+      {/* Manual Entry Modal */}
+      <ManualEntryModal
+        visible={manualEntryVisible}
+        onClose={handleManualClose}
+        onSave={handleManualSave}
+        saving={saving}
+        initialActivityType={manualActivityType}
+      />
     </View>
   );
 }
@@ -14,11 +262,104 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: colors.background,
+  },
+  content: {
+    padding: spacing.lg,
+  },
+  voiceSection: {
+    alignItems: 'center',
+    backgroundColor: colors.surface,
+    borderRadius: layout.radiusLarge,
+    padding: spacing.lg,
+    marginBottom: spacing.lg,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 2,
+    elevation: 1,
+  },
+  micButton: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    backgroundColor: `${colors.primary}15`,
     justifyContent: 'center',
     alignItems: 'center',
+    marginBottom: spacing.md,
   },
-  text: {
-    fontSize: 18,
+  micEmoji: {
+    fontSize: 40,
+  },
+  voiceTitle: {
+    fontSize: typography.lg,
+    fontWeight: '600' as const,
+    color: colors.textPrimary,
+    marginBottom: spacing.md,
+  },
+  examplesContainer: {
+    width: '100%',
+    backgroundColor: colors.background,
+    padding: spacing.md,
+    borderRadius: layout.radiusMedium,
+  },
+  examplesTitle: {
+    fontSize: typography.sm,
+    fontWeight: '600' as const,
+    color: colors.textPrimary,
+    marginBottom: spacing.xs,
+  },
+  exampleText: {
+    fontSize: typography.sm,
     color: colors.textSecondary,
+    marginBottom: 4,
+  },
+  gridTitle: {
+    fontSize: typography.base,
+    fontWeight: '600' as const,
+    color: colors.textPrimary,
+    marginBottom: spacing.md,
+  },
+  activityGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+  },
+  activityCard: {
+    width: '30%',
+    aspectRatio: 1,
+    backgroundColor: colors.surface,
+    borderRadius: layout.radiusMedium,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacing.sm,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 2,
+    elevation: 1,
+  },
+  activityCardDisabled: {
+    opacity: 0.5,
+  },
+  activityIconContainer: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: spacing.xs,
+  },
+  activityCardLabel: {
+    fontSize: typography.sm,
+    fontWeight: '600' as const,
+    color: colors.textPrimary,
+  },
+  activityCardLabelDisabled: {
+    color: colors.textLight,
+  },
+  comingSoonText: {
+    fontSize: typography.xs,
+    color: colors.textLight,
+    marginTop: 2,
   },
 });


### PR DESCRIPTION
## Summary

Closes #63

- Build Log Activity screen with voice input and activity type grid (#63)

## Test plan

- [ ] Verify the changes address the issue requirements
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)