### PR TITLE
Fix #65: Add paginated session history query for infinite scroll

### DIFF
--- a/backend/graph/generated.go
+++ b/backend/graph/generated.go
@@ -72,6 +72,21 @@ type ComplexityRoot struct {
 		Summary     func(childComplexity int) int
 	}
 
+	CareSessionConnection struct {
+		Edges    func(childComplexity int) int
+		PageInfo func(childComplexity int) int
+	}
+
+	CareSessionEdge struct {
+		Cursor func(childComplexity int) int
+		Node   func(childComplexity int) int
+	}
+
+	CareSessionPageInfo struct {
+		EndCursor   func(childComplexity int) int
+		HasNextPage func(childComplexity int) int
+	}
+
 	CareSessionSummary struct {
 		CurrentlyAsleep    func(childComplexity int) int
 		LastFeedTime       func(childComplexity int) int
@@ -171,6 +186,7 @@ type ComplexityRoot struct {
 		CheckFamilyNameAvailable func(childComplexity int, name string) int
 		GetBabyStatus            func(childComplexity int) int
 		GetCareSession           func(childComplexity int, id string) int
+		GetCareSessionHistory    func(childComplexity int, first int32, after *string) int
 		GetCurrentSession        func(childComplexity int) int
 		GetMyCaregiver           func(childComplexity int) int
 		GetMyFamilies            func(childComplexity int) int
@@ -217,6 +233,7 @@ type QueryResolver interface {
 	GetCurrentSession(ctx context.Context) (*model.CareSession, error)
 	GetCareSession(ctx context.Context, id string) (*model.CareSession, error)
 	GetBabyStatus(ctx context.Context) (*model.BabyStatus, error)
+	GetCareSessionHistory(ctx context.Context, first int32, after *string) (*model.CareSessionConnection, error)
 	PredictNextFeed(ctx context.Context) (*model.NextFeedPrediction, error)
 }
 
@@ -337,6 +354,45 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.CareSession.Summary(childComplexity), true
+
+	case "CareSessionConnection.edges":
+		if e.complexity.CareSessionConnection.Edges == nil {
+			break
+		}
+
+		return e.complexity.CareSessionConnection.Edges(childComplexity), true
+	case "CareSessionConnection.pageInfo":
+		if e.complexity.CareSessionConnection.PageInfo == nil {
+			break
+		}
+
+		return e.complexity.CareSessionConnection.PageInfo(childComplexity), true
+
+	case "CareSessionEdge.cursor":
+		if e.complexity.CareSessionEdge.Cursor == nil {
+			break
+		}
+
+		return e.complexity.CareSessionEdge.Cursor(childComplexity), true
+	case "CareSessionEdge.node":
+		if e.complexity.CareSessionEdge.Node == nil {
+			break
+		}
+
+		return e.complexity.CareSessionEdge.Node(childComplexity), true
+
+	case "CareSessionPageInfo.endCursor":
+		if e.complexity.CareSessionPageInfo.EndCursor == nil {
+			break
+		}
+
+		return e.complexity.CareSessionPageInfo.EndCursor(childComplexity), true
+	case "CareSessionPageInfo.hasNextPage":
+		if e.complexity.CareSessionPageInfo.HasNextPage == nil {
+			break
+		}
+
+		return e.complexity.CareSessionPageInfo.HasNextPage(childComplexity), true
 
 	case "CareSessionSummary.currentlyAsleep":
 		if e.complexity.CareSessionSummary.CurrentlyAsleep == nil {
@@ -799,6 +855,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.GetCareSession(childComplexity, args["id"].(string)), true
+	case "Query.getCareSessionHistory":
+		if e.complexity.Query.GetCareSessionHistory == nil {
+			break
+		}
+
+		args, err := ec.field_Query_getCareSessionHistory_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.GetCareSessionHistory(childComplexity, args["first"].(int32), args["after"].(*string)), true
 	case "Query.getCurrentSession":
 		if e.complexity.Query.GetCurrentSession == nil {
 			break
@@ -1122,6 +1189,21 @@ type SleepActivity {
   sleepDetails: SleepDetails
 }
 
+type CareSessionEdge {
+  node: CareSession!
+  cursor: String!
+}
+
+type CareSessionPageInfo {
+  hasNextPage: Boolean!
+  endCursor: String
+}
+
+type CareSessionConnection {
+  edges: [CareSessionEdge!]!
+  pageInfo: CareSessionPageInfo!
+}
+
 type BabyStatus {
   lastFeed: FeedActivity
   lastDiaper: DiaperActivity
@@ -1201,6 +1283,9 @@ type Query {
 
   # Baby Status
   getBabyStatus: BabyStatus!
+
+  # Session History (paginated)
+  getCareSessionHistory(first: Int!, after: String): CareSessionConnection!
 
   # Predictions
   predictNextFeed: NextFeedPrediction!
@@ -1439,6 +1524,22 @@ func (ec *executionContext) field_Query_checkFamilyNameAvailable_args(ctx contex
 		return nil, err
 	}
 	args["name"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_getCareSessionHistory_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "first", ec.unmarshalNInt2int32)
+	if err != nil {
+		return nil, err
+	}
+	args["first"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "after", ec.unmarshalOString2ᚖstring)
+	if err != nil {
+		return nil, err
+	}
+	args["after"] = arg1
 	return args, nil
 }
 
@@ -2063,6 +2164,212 @@ func (ec *executionContext) fieldContext_CareSession_summary(_ context.Context, 
 				return ec.fieldContext_CareSessionSummary_currentlyAsleep(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type CareSessionSummary", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CareSessionConnection_edges(ctx context.Context, field graphql.CollectedField, obj *model.CareSessionConnection) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_CareSessionConnection_edges,
+		func(ctx context.Context) (any, error) {
+			return obj.Edges, nil
+		},
+		nil,
+		ec.marshalNCareSessionEdge2ᚕᚖgithubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐCareSessionEdgeᚄ,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_CareSessionConnection_edges(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CareSessionConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "node":
+				return ec.fieldContext_CareSessionEdge_node(ctx, field)
+			case "cursor":
+				return ec.fieldContext_CareSessionEdge_cursor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CareSessionEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CareSessionConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *model.CareSessionConnection) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_CareSessionConnection_pageInfo,
+		func(ctx context.Context) (any, error) {
+			return obj.PageInfo, nil
+		},
+		nil,
+		ec.marshalNCareSessionPageInfo2ᚖgithubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐCareSessionPageInfo,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_CareSessionConnection_pageInfo(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CareSessionConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "hasNextPage":
+				return ec.fieldContext_CareSessionPageInfo_hasNextPage(ctx, field)
+			case "endCursor":
+				return ec.fieldContext_CareSessionPageInfo_endCursor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CareSessionPageInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CareSessionEdge_node(ctx context.Context, field graphql.CollectedField, obj *model.CareSessionEdge) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_CareSessionEdge_node,
+		func(ctx context.Context) (any, error) {
+			return obj.Node, nil
+		},
+		nil,
+		ec.marshalNCareSession2ᚖgithubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐCareSession,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_CareSessionEdge_node(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CareSessionEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_CareSession_id(ctx, field)
+			case "caregiver":
+				return ec.fieldContext_CareSession_caregiver(ctx, field)
+			case "familyId":
+				return ec.fieldContext_CareSession_familyId(ctx, field)
+			case "status":
+				return ec.fieldContext_CareSession_status(ctx, field)
+			case "startedAt":
+				return ec.fieldContext_CareSession_startedAt(ctx, field)
+			case "completedAt":
+				return ec.fieldContext_CareSession_completedAt(ctx, field)
+			case "activities":
+				return ec.fieldContext_CareSession_activities(ctx, field)
+			case "notes":
+				return ec.fieldContext_CareSession_notes(ctx, field)
+			case "summary":
+				return ec.fieldContext_CareSession_summary(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CareSession", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CareSessionEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *model.CareSessionEdge) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_CareSessionEdge_cursor,
+		func(ctx context.Context) (any, error) {
+			return obj.Cursor, nil
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_CareSessionEdge_cursor(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CareSessionEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CareSessionPageInfo_hasNextPage(ctx context.Context, field graphql.CollectedField, obj *model.CareSessionPageInfo) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_CareSessionPageInfo_hasNextPage,
+		func(ctx context.Context) (any, error) {
+			return obj.HasNextPage, nil
+		},
+		nil,
+		ec.marshalNBoolean2bool,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_CareSessionPageInfo_hasNextPage(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CareSessionPageInfo",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CareSessionPageInfo_endCursor(ctx context.Context, field graphql.CollectedField, obj *model.CareSessionPageInfo) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_CareSessionPageInfo_endCursor,
+		func(ctx context.Context) (any, error) {
+			return obj.EndCursor, nil
+		},
+		nil,
+		ec.marshalOString2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_CareSessionPageInfo_endCursor(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CareSessionPageInfo",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -4568,6 +4875,53 @@ func (ec *executionContext) fieldContext_Query_getBabyStatus(_ context.Context, 
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_getCareSessionHistory(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_getCareSessionHistory,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.resolvers.Query().GetCareSessionHistory(ctx, fc.Args["first"].(int32), fc.Args["after"].(*string))
+		},
+		nil,
+		ec.marshalNCareSessionConnection2ᚖgithubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐCareSessionConnection,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_getCareSessionHistory(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "edges":
+				return ec.fieldContext_CareSessionConnection_edges(ctx, field)
+			case "pageInfo":
+				return ec.fieldContext_CareSessionConnection_pageInfo(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CareSessionConnection", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_getCareSessionHistory_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_predictNextFeed(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -6791,6 +7145,135 @@ func (ec *executionContext) _CareSession(ctx context.Context, sel ast.SelectionS
 	return out
 }
 
+var careSessionConnectionImplementors = []string{"CareSessionConnection"}
+
+func (ec *executionContext) _CareSessionConnection(ctx context.Context, sel ast.SelectionSet, obj *model.CareSessionConnection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, careSessionConnectionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CareSessionConnection")
+		case "edges":
+			out.Values[i] = ec._CareSessionConnection_edges(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "pageInfo":
+			out.Values[i] = ec._CareSessionConnection_pageInfo(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var careSessionEdgeImplementors = []string{"CareSessionEdge"}
+
+func (ec *executionContext) _CareSessionEdge(ctx context.Context, sel ast.SelectionSet, obj *model.CareSessionEdge) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, careSessionEdgeImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CareSessionEdge")
+		case "node":
+			out.Values[i] = ec._CareSessionEdge_node(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "cursor":
+			out.Values[i] = ec._CareSessionEdge_cursor(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var careSessionPageInfoImplementors = []string{"CareSessionPageInfo"}
+
+func (ec *executionContext) _CareSessionPageInfo(ctx context.Context, sel ast.SelectionSet, obj *model.CareSessionPageInfo) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, careSessionPageInfoImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CareSessionPageInfo")
+		case "hasNextPage":
+			out.Values[i] = ec._CareSessionPageInfo_hasNextPage(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "endCursor":
+			out.Values[i] = ec._CareSessionPageInfo_endCursor(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var careSessionSummaryImplementors = []string{"CareSessionSummary"}
 
 func (ec *executionContext) _CareSessionSummary(ctx context.Context, sel ast.SelectionSet, obj *model.CareSessionSummary) graphql.Marshaler {
@@ -7639,6 +8122,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "getCareSessionHistory":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_getCareSessionHistory(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "predictNextFeed":
 			field := field
 
@@ -8312,6 +8817,84 @@ func (ec *executionContext) marshalNCareSession2ᚖgithubᚗcomᚋswatkatzᚋbab
 		return graphql.Null
 	}
 	return ec._CareSession(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNCareSessionConnection2githubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐCareSessionConnection(ctx context.Context, sel ast.SelectionSet, v model.CareSessionConnection) graphql.Marshaler {
+	return ec._CareSessionConnection(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNCareSessionConnection2ᚖgithubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐCareSessionConnection(ctx context.Context, sel ast.SelectionSet, v *model.CareSessionConnection) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CareSessionConnection(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNCareSessionEdge2ᚕᚖgithubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐCareSessionEdgeᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.CareSessionEdge) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNCareSessionEdge2ᚖgithubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐCareSessionEdge(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNCareSessionEdge2ᚖgithubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐCareSessionEdge(ctx context.Context, sel ast.SelectionSet, v *model.CareSessionEdge) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CareSessionEdge(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNCareSessionPageInfo2ᚖgithubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐCareSessionPageInfo(ctx context.Context, sel ast.SelectionSet, v *model.CareSessionPageInfo) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CareSessionPageInfo(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNCareSessionStatus2githubᚗcomᚋswatkatzᚋbabybatonᚋbackendᚋgraphᚋmodelᚐCareSessionStatus(ctx context.Context, v any) (model.CareSessionStatus, error) {

--- a/backend/graph/mock_store_test.go
+++ b/backend/graph/mock_store_test.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/swatkatz/babybaton/backend/internal/domain"
@@ -28,6 +29,10 @@ type mockStore struct {
 	getCaregiverByDeviceIDErr     error
 	caregiverByUserAndFamily      *domain.Caregiver
 	getCaregiverByUserAndFamilyErr error
+
+	// Session history
+	careSessionHistory    []*domain.CareSession
+	careSessionHistoryErr error
 
 	// Baby status
 	latestActivityByType map[domain.ActivityType]*domain.Activity
@@ -150,6 +155,12 @@ func (m *mockStore) GetInProgressSessionForFamily(_ context.Context, _ uuid.UUID
 }
 func (m *mockStore) GetRecentCareSessionsForFamily(_ context.Context, _ uuid.UUID, _ int) ([]*domain.CareSession, error) {
 	return nil, nil
+}
+func (m *mockStore) GetCareSessionHistoryForFamily(_ context.Context, _ uuid.UUID, _ int, _ *time.Time, _ *uuid.UUID) ([]*domain.CareSession, error) {
+	if m.careSessionHistoryErr != nil {
+		return nil, m.careSessionHistoryErr
+	}
+	return m.careSessionHistory, nil
 }
 func (m *mockStore) UpdateCareSession(_ context.Context, _ *domain.CareSession) error { return nil }
 func (m *mockStore) DeleteCareSession(_ context.Context, _ uuid.UUID) error            { return nil }

--- a/backend/graph/model/models_gen.go
+++ b/backend/graph/model/models_gen.go
@@ -46,6 +46,21 @@ type CareSession struct {
 	Summary     *CareSessionSummary `json:"summary"`
 }
 
+type CareSessionConnection struct {
+	Edges    []*CareSessionEdge   `json:"edges"`
+	PageInfo *CareSessionPageInfo `json:"pageInfo"`
+}
+
+type CareSessionEdge struct {
+	Node   *CareSession `json:"node"`
+	Cursor string       `json:"cursor"`
+}
+
+type CareSessionPageInfo struct {
+	HasNextPage bool    `json:"hasNextPage"`
+	EndCursor   *string `json:"endCursor,omitempty"`
+}
+
 type CareSessionSummary struct {
 	TotalFeeds         int32      `json:"totalFeeds"`
 	TotalMl            int32      `json:"totalMl"`

--- a/backend/graph/schema.resolvers.go
+++ b/backend/graph/schema.resolvers.go
@@ -1061,9 +1061,9 @@ func (r *queryResolver) GetBabyStatus(ctx context.Context) (*model.BabyStatus, e
 			return nil, fmt.Errorf("failed to get diaper details: %w", err)
 		}
 		status.LastDiaper = &model.DiaperActivity{
-			ID:           diaperActivity.ID.String(),
-			ActivityType: model.ActivityTypeDiaper,
-			CreatedAt:    diaperActivity.CreatedAt,
+			ID:            diaperActivity.ID.String(),
+			ActivityType:  model.ActivityTypeDiaper,
+			CreatedAt:     diaperActivity.CreatedAt,
 			DiaperDetails: mapper.DiaperDetailsToGraphQL(diaperDetails),
 		}
 	}
@@ -1087,6 +1087,67 @@ func (r *queryResolver) GetBabyStatus(ctx context.Context) (*model.BabyStatus, e
 	}
 
 	return status, nil
+}
+
+// GetCareSessionHistory is the resolver for the getCareSessionHistory field.
+func (r *queryResolver) GetCareSessionHistory(ctx context.Context, first int32, after *string) (*model.CareSessionConnection, error) {
+	_, familyID, err := middleware.RequireAuth(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("authentication required: %w", err)
+	}
+
+	if first <= 0 {
+		return nil, fmt.Errorf("first must be greater than 0")
+	}
+
+	var afterTime *time.Time
+	var afterID *uuid.UUID
+	if after != nil {
+		t, id, err := domain.DecodeCursor(*after)
+		if err != nil {
+			return nil, fmt.Errorf("invalid cursor: %w", err)
+		}
+		afterTime = &t
+		afterID = &id
+	}
+
+	// Fetch first+1 to determine hasNextPage
+	fetchLimit := int(first) + 1
+	sessions, err := r.store.GetCareSessionHistoryForFamily(ctx, familyID, fetchLimit, afterTime, afterID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get session history: %w", err)
+	}
+
+	hasNextPage := len(sessions) > int(first)
+	if hasNextPage {
+		sessions = sessions[:first]
+	}
+
+	edges := make([]*model.CareSessionEdge, 0, len(sessions))
+	for _, session := range sessions {
+		loaded, err := r.loadCareSessionWithActivities(ctx, session)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load session %s: %w", session.ID, err)
+		}
+		cursor := domain.EncodeCursor(session.StartedAt, session.ID)
+		edges = append(edges, &model.CareSessionEdge{
+			Node:   loaded,
+			Cursor: cursor,
+		})
+	}
+
+	var endCursor *string
+	if len(edges) > 0 {
+		endCursor = &edges[len(edges)-1].Cursor
+	}
+
+	return &model.CareSessionConnection{
+		Edges: edges,
+		PageInfo: &model.CareSessionPageInfo{
+			HasNextPage: hasNextPage,
+			EndCursor:   endCursor,
+		},
+	}, nil
 }
 
 // PredictNextFeed is the resolver for the predictNextFeed field.

--- a/backend/graph/schema.resolvers_test.go
+++ b/backend/graph/schema.resolvers_test.go
@@ -657,3 +657,137 @@ func TestGetBabyStatus_Unauthenticated(t *testing.T) {
 func testing_time() time.Time {
 	return time.Date(2026, 3, 28, 12, 0, 0, 0, time.UTC)
 }
+
+// ==================== GetCareSessionHistory Tests ====================
+
+func makeTestSessions(familyID, caregiverID uuid.UUID, count int) []*domain.CareSession {
+	now := time.Now().UTC()
+	sessions := make([]*domain.CareSession, count)
+	for i := 0; i < count; i++ {
+		sessions[i] = &domain.CareSession{
+			ID:          uuid.New(),
+			CaregiverID: caregiverID,
+			FamilyID:    familyID,
+			Status:      domain.StatusCompleted,
+			StartedAt:   now.Add(time.Duration(-i) * time.Hour),
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+	}
+	return sessions
+}
+
+func TestGetCareSessionHistory_FirstPage(t *testing.T) {
+	familyID := uuid.New()
+	caregiverID := uuid.New()
+	sessions := makeTestSessions(familyID, caregiverID, 3)
+
+	store := newMockStore()
+	store.caregiverByID = &domain.Caregiver{ID: caregiverID, FamilyID: familyID, Name: "Test"}
+	// Mock returns first+1 = 3 sessions to indicate hasNextPage
+	store.careSessionHistory = sessions
+	resolver := NewResolver(store)
+	qr := &queryResolver{resolver}
+	ctx := withAuth(context.Background(), caregiverID, familyID)
+
+	result, err := qr.GetCareSessionHistory(ctx, 2, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Edges) != 2 {
+		t.Fatalf("expected 2 edges, got %d", len(result.Edges))
+	}
+	if !result.PageInfo.HasNextPage {
+		t.Error("expected hasNextPage to be true")
+	}
+	if result.PageInfo.EndCursor == nil {
+		t.Error("expected endCursor to be set")
+	}
+}
+
+func TestGetCareSessionHistory_LastPage(t *testing.T) {
+	familyID := uuid.New()
+	caregiverID := uuid.New()
+	sessions := makeTestSessions(familyID, caregiverID, 1)
+
+	store := newMockStore()
+	store.caregiverByID = &domain.Caregiver{ID: caregiverID, FamilyID: familyID, Name: "Test"}
+	store.careSessionHistory = sessions
+	resolver := NewResolver(store)
+	qr := &queryResolver{resolver}
+	ctx := withAuth(context.Background(), caregiverID, familyID)
+
+	result, err := qr.GetCareSessionHistory(ctx, 2, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Edges) != 1 {
+		t.Fatalf("expected 1 edge, got %d", len(result.Edges))
+	}
+	if result.PageInfo.HasNextPage {
+		t.Error("expected hasNextPage to be false")
+	}
+}
+
+func TestGetCareSessionHistory_EmptyResults(t *testing.T) {
+	familyID := uuid.New()
+	caregiverID := uuid.New()
+
+	store := newMockStore()
+	store.careSessionHistory = []*domain.CareSession{}
+	resolver := NewResolver(store)
+	qr := &queryResolver{resolver}
+	ctx := withAuth(context.Background(), caregiverID, familyID)
+
+	result, err := qr.GetCareSessionHistory(ctx, 10, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Edges) != 0 {
+		t.Errorf("expected 0 edges, got %d", len(result.Edges))
+	}
+	if result.PageInfo.HasNextPage {
+		t.Error("expected hasNextPage to be false")
+	}
+	if result.PageInfo.EndCursor != nil {
+		t.Error("expected endCursor to be nil")
+	}
+}
+
+func TestGetCareSessionHistory_NotAuthenticated(t *testing.T) {
+	store := newMockStore()
+	resolver := NewResolver(store)
+	qr := &queryResolver{resolver}
+	ctx := context.Background() // no auth
+
+	_, err := qr.GetCareSessionHistory(ctx, 10, nil)
+	if err == nil {
+		t.Fatal("expected error for unauthenticated request")
+	}
+}
+
+func TestGetCareSessionHistory_EdgesHaveCursors(t *testing.T) {
+	familyID := uuid.New()
+	caregiverID := uuid.New()
+	sessions := makeTestSessions(familyID, caregiverID, 2)
+
+	store := newMockStore()
+	store.caregiverByID = &domain.Caregiver{ID: caregiverID, FamilyID: familyID, Name: "Test"}
+	store.careSessionHistory = sessions
+	resolver := NewResolver(store)
+	qr := &queryResolver{resolver}
+	ctx := withAuth(context.Background(), caregiverID, familyID)
+
+	result, err := qr.GetCareSessionHistory(ctx, 10, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i, edge := range result.Edges {
+		if edge.Cursor == "" {
+			t.Errorf("edge %d has empty cursor", i)
+		}
+		if edge.Node == nil {
+			t.Errorf("edge %d has nil node", i)
+		}
+	}
+}

--- a/backend/internal/domain/cursor.go
+++ b/backend/internal/domain/cursor.go
@@ -1,0 +1,42 @@
+package domain
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// EncodeCursor creates a cursor string from a timestamp and UUID.
+// Format: base64(RFC3339Nano + ":" + UUID)
+func EncodeCursor(t time.Time, id uuid.UUID) string {
+	raw := t.UTC().Format(time.RFC3339Nano) + "|" + id.String()
+	return base64.StdEncoding.EncodeToString([]byte(raw))
+}
+
+// DecodeCursor parses a cursor string back into a timestamp and UUID.
+func DecodeCursor(cursor string) (time.Time, uuid.UUID, error) {
+	decoded, err := base64.StdEncoding.DecodeString(cursor)
+	if err != nil {
+		return time.Time{}, uuid.Nil, fmt.Errorf("invalid cursor: not valid base64")
+	}
+
+	parts := strings.SplitN(string(decoded), "|", 2)
+	if len(parts) != 2 {
+		return time.Time{}, uuid.Nil, fmt.Errorf("invalid cursor: missing separator")
+	}
+
+	t, err := time.Parse(time.RFC3339Nano, parts[0])
+	if err != nil {
+		return time.Time{}, uuid.Nil, fmt.Errorf("invalid cursor: bad timestamp")
+	}
+
+	id, err := uuid.Parse(parts[1])
+	if err != nil {
+		return time.Time{}, uuid.Nil, fmt.Errorf("invalid cursor: bad UUID")
+	}
+
+	return t, id, nil
+}

--- a/backend/internal/domain/cursor_test.go
+++ b/backend/internal/domain/cursor_test.go
@@ -1,0 +1,71 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestEncodeCursor_RoundTrip(t *testing.T) {
+	originalTime := time.Date(2026, 3, 15, 10, 30, 0, 123456789, time.UTC)
+	originalID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+
+	cursor := EncodeCursor(originalTime, originalID)
+	if cursor == "" {
+		t.Fatal("expected non-empty cursor")
+	}
+
+	decodedTime, decodedID, err := DecodeCursor(cursor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !decodedTime.Equal(originalTime) {
+		t.Errorf("time mismatch: got %v, want %v", decodedTime, originalTime)
+	}
+	if decodedID != originalID {
+		t.Errorf("UUID mismatch: got %v, want %v", decodedID, originalID)
+	}
+}
+
+func TestEncodeCursor_NormalizesToUTC(t *testing.T) {
+	loc := time.FixedZone("EST", -5*60*60)
+	localTime := time.Date(2026, 3, 15, 10, 0, 0, 0, loc)
+	id := uuid.New()
+
+	cursor := EncodeCursor(localTime, id)
+	decodedTime, _, err := DecodeCursor(cursor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !decodedTime.Equal(localTime) {
+		t.Errorf("times should be equal: got %v, want %v", decodedTime, localTime)
+	}
+	if decodedTime.Location() != time.UTC {
+		t.Errorf("expected UTC location, got %v", decodedTime.Location())
+	}
+}
+
+func TestDecodeCursor_Invalid(t *testing.T) {
+	tests := []struct {
+		name   string
+		cursor string
+	}{
+		{"empty string", ""},
+		{"not base64", "!!!not-base64!!!"},
+		{"missing separator", "bm9zZXBhcmF0b3I="},                                         // "noseparator"
+		{"bad timestamp", "YmFkdGltZTpjMjEwOGViMC1jOGQ4LTRiN2UtOTAxYS0wZmQyYzJjMjNhYTQ="}, // "badtime:c2108eb0-..."
+		{"bad UUID", "MjAyNi0wMy0xNVQxMDozMDowMFo6bm90LWEtdXVpZA=="},                       // "2026-03-15T10:30:00Z:not-a-uuid"
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := DecodeCursor(tt.cursor)
+			if err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}

--- a/backend/internal/middleware/auth_test.go
+++ b/backend/internal/middleware/auth_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/swatkatz/babybaton/backend/internal/domain"
@@ -98,6 +99,9 @@ func (m *mockStore) GetInProgressSessionForFamily(ctx context.Context, familyID 
 	return nil, nil
 }
 func (m *mockStore) GetRecentCareSessionsForFamily(ctx context.Context, familyID uuid.UUID, limit int) ([]*domain.CareSession, error) {
+	return nil, nil
+}
+func (m *mockStore) GetCareSessionHistoryForFamily(ctx context.Context, familyID uuid.UUID, limit int, afterTime *time.Time, afterID *uuid.UUID) ([]*domain.CareSession, error) {
 	return nil, nil
 }
 func (m *mockStore) UpdateCareSession(ctx context.Context, session *domain.CareSession) error {

--- a/backend/internal/store/postgres/care_session.go
+++ b/backend/internal/store/postgres/care_session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/swatkatz/babybaton/backend/internal/domain"
@@ -99,6 +100,63 @@ func (s *PostgresStore) GetRecentCareSessionsForFamily(ctx context.Context, fami
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to query recent sessions: %w", err)
+	}
+	defer rows.Close()
+
+	var sessions []*domain.CareSession
+	for rows.Next() {
+		session := &domain.CareSession{}
+		err := rows.Scan(
+			&session.ID,
+			&session.CaregiverID,
+			&session.FamilyID,
+			&session.Status,
+			&session.StartedAt,
+			&session.CompletedAt,
+			&session.Notes,
+			&session.CreatedAt,
+			&session.UpdatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan session: %w", err)
+		}
+		sessions = append(sessions, session)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating sessions: %w", err)
+	}
+
+	return sessions, nil
+}
+
+// GetCareSessionHistoryForFamily retrieves paginated sessions for a family using keyset pagination.
+// Returns all statuses (in_progress + completed), ordered newest first.
+// When afterTime/afterID are provided, returns sessions after that cursor position.
+func (s *PostgresStore) GetCareSessionHistoryForFamily(ctx context.Context, familyID uuid.UUID, limit int, afterTime *time.Time, afterID *uuid.UUID) ([]*domain.CareSession, error) {
+	var rows *sql.Rows
+	var err error
+
+	if afterTime != nil && afterID != nil {
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT id, caregiver_id, family_id, status, started_at, completed_at, notes, created_at, updated_at
+			FROM care_sessions
+			WHERE family_id = $1 AND (started_at < $2 OR (started_at = $2 AND id < $3))
+			ORDER BY started_at DESC, id DESC
+			LIMIT $4
+		`, familyID, *afterTime, *afterID, limit)
+	} else {
+		rows, err = s.db.QueryContext(ctx, `
+			SELECT id, caregiver_id, family_id, status, started_at, completed_at, notes, created_at, updated_at
+			FROM care_sessions
+			WHERE family_id = $1
+			ORDER BY started_at DESC, id DESC
+			LIMIT $2
+		`, familyID, limit)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to query session history: %w", err)
 	}
 	defer rows.Close()
 

--- a/backend/internal/store/postgres/care_session_test.go
+++ b/backend/internal/store/postgres/care_session_test.go
@@ -156,6 +156,170 @@ func TestCareSessionOperations(t *testing.T) {
 	})
 }
 
+func TestGetCareSessionHistoryForFamily(t *testing.T) {
+	store, err := NewPostgresStore("postgres://postgres:postgres@localhost:5432/baby_baton_test?sslmode=disable")
+	if err != nil {
+		t.Fatalf("Failed to connect to database: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+
+	family, caregiver, err := CreateTestFamily(ctx, store)
+	if err != nil {
+		t.Fatalf("Failed to create test family: %v", err)
+	}
+	t.Cleanup(func() {
+		store.DeleteFamily(ctx, family.ID)
+	})
+
+	// Create 5 sessions with distinct timestamps and statuses
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	sessions := make([]*domain.CareSession, 5)
+	for i := 0; i < 5; i++ {
+		status := domain.StatusCompleted
+		var completedAt *time.Time
+		if i == 0 {
+			// newest session is in_progress
+			status = domain.StatusInProgress
+		} else {
+			ct := now.Add(time.Duration(-i) * time.Hour).Add(30 * time.Minute)
+			completedAt = &ct
+		}
+		sessions[i] = &domain.CareSession{
+			ID:          uuid.New(),
+			CaregiverID: caregiver.ID,
+			FamilyID:    family.ID,
+			Status:      status,
+			StartedAt:   now.Add(time.Duration(-i) * time.Hour),
+			CompletedAt: completedAt,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+		if err := store.CreateCareSession(ctx, sessions[i]); err != nil {
+			t.Fatalf("Failed to create session %d: %v", i, err)
+		}
+	}
+
+	t.Run("FirstPage", func(t *testing.T) {
+		results, err := store.GetCareSessionHistoryForFamily(ctx, family.ID, 3, nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 3 {
+			t.Fatalf("expected 3 sessions, got %d", len(results))
+		}
+		// Should be newest first (sessions[0] is newest)
+		if results[0].ID != sessions[0].ID {
+			t.Errorf("expected first result to be newest session")
+		}
+	})
+
+	t.Run("NextPage_WithCursor", func(t *testing.T) {
+		// Get first page
+		firstPage, err := store.GetCareSessionHistoryForFamily(ctx, family.ID, 3, nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Use last item of first page as cursor
+		lastSession := firstPage[len(firstPage)-1]
+		afterTime := lastSession.StartedAt
+		afterID := lastSession.ID
+
+		secondPage, err := store.GetCareSessionHistoryForFamily(ctx, family.ID, 3, &afterTime, &afterID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(secondPage) != 2 {
+			t.Fatalf("expected 2 sessions on second page, got %d", len(secondPage))
+		}
+
+		// No overlap with first page
+		firstPageIDs := map[uuid.UUID]bool{}
+		for _, s := range firstPage {
+			firstPageIDs[s.ID] = true
+		}
+		for _, s := range secondPage {
+			if firstPageIDs[s.ID] {
+				t.Errorf("session %s appears in both pages", s.ID)
+			}
+		}
+	})
+
+	t.Run("IncludesBothStatuses", func(t *testing.T) {
+		results, err := store.GetCareSessionHistoryForFamily(ctx, family.ID, 10, nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		hasInProgress := false
+		hasCompleted := false
+		for _, s := range results {
+			if s.Status == domain.StatusInProgress {
+				hasInProgress = true
+			}
+			if s.Status == domain.StatusCompleted {
+				hasCompleted = true
+			}
+		}
+		if !hasInProgress {
+			t.Error("expected at least one in_progress session")
+		}
+		if !hasCompleted {
+			t.Error("expected at least one completed session")
+		}
+	})
+
+	t.Run("EmptyResults", func(t *testing.T) {
+		nonExistentFamily := uuid.New()
+		results, err := store.GetCareSessionHistoryForFamily(ctx, nonExistentFamily, 10, nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 0 {
+			t.Errorf("expected 0 sessions, got %d", len(results))
+		}
+	})
+
+	t.Run("SingleItemPage", func(t *testing.T) {
+		results, err := store.GetCareSessionHistoryForFamily(ctx, family.ID, 1, nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 session, got %d", len(results))
+		}
+		if results[0].ID != sessions[0].ID {
+			t.Errorf("expected newest session")
+		}
+	})
+
+	t.Run("BeyondLastPage", func(t *testing.T) {
+		// Use a cursor that's older than all sessions
+		oldTime := now.Add(-100 * time.Hour)
+		oldID := uuid.New()
+		results, err := store.GetCareSessionHistoryForFamily(ctx, family.ID, 10, &oldTime, &oldID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) != 0 {
+			t.Errorf("expected 0 sessions beyond last page, got %d", len(results))
+		}
+	})
+
+	t.Run("OrderIsNewestFirst", func(t *testing.T) {
+		results, err := store.GetCareSessionHistoryForFamily(ctx, family.ID, 10, nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for i := 1; i < len(results); i++ {
+			if results[i].StartedAt.After(results[i-1].StartedAt) {
+				t.Errorf("session %d started after session %d (not DESC order)", i, i-1)
+			}
+		}
+	})
+}
+
 func timePtr(t time.Time) *time.Time {
 	return &t
 }

--- a/backend/internal/store/store.go
+++ b/backend/internal/store/store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/swatkatz/babybaton/backend/internal/domain"
@@ -38,6 +39,7 @@ type Store interface {
 	GetCareSessionByID(ctx context.Context, id uuid.UUID) (*domain.CareSession, error)
 	GetInProgressSessionForFamily(ctx context.Context, familyID uuid.UUID) (*domain.CareSession, error)
 	GetRecentCareSessionsForFamily(ctx context.Context, familyID uuid.UUID, limit int) ([]*domain.CareSession, error)
+	GetCareSessionHistoryForFamily(ctx context.Context, familyID uuid.UUID, limit int, afterTime *time.Time, afterID *uuid.UUID) ([]*domain.CareSession, error)
 	UpdateCareSession(ctx context.Context, session *domain.CareSession) error
 	DeleteCareSession(ctx context.Context, id uuid.UUID) error
 

--- a/frontend/src/types/__generated__/graphql.ts
+++ b/frontend/src/types/__generated__/graphql.ts
@@ -60,6 +60,24 @@ export type CareSession = {
   summary: CareSessionSummary;
 };
 
+export type CareSessionConnection = {
+  __typename: 'CareSessionConnection';
+  edges: Array<CareSessionEdge>;
+  pageInfo: CareSessionPageInfo;
+};
+
+export type CareSessionEdge = {
+  __typename: 'CareSessionEdge';
+  cursor: Scalars['String']['output'];
+  node: CareSession;
+};
+
+export type CareSessionPageInfo = {
+  __typename: 'CareSessionPageInfo';
+  endCursor: Maybe<Scalars['String']['output']>;
+  hasNextPage: Scalars['Boolean']['output'];
+};
+
 export enum CareSessionStatus {
   Completed = 'COMPLETED',
   InProgress = 'IN_PROGRESS'
@@ -265,6 +283,7 @@ export type Query = {
   checkFamilyNameAvailable: Scalars['Boolean']['output'];
   getBabyStatus: BabyStatus;
   getCareSession: Maybe<CareSession>;
+  getCareSessionHistory: CareSessionConnection;
   getCurrentSession: Maybe<CareSession>;
   getMyCaregiver: Maybe<Caregiver>;
   getMyFamilies: Array<Family>;
@@ -281,6 +300,12 @@ export type QueryCheckFamilyNameAvailableArgs = {
 
 export type QueryGetCareSessionArgs = {
   id: Scalars['ID']['input'];
+};
+
+
+export type QueryGetCareSessionHistoryArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
 };
 
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -120,6 +120,21 @@ type SleepActivity {
   sleepDetails: SleepDetails
 }
 
+type CareSessionEdge {
+  node: CareSession!
+  cursor: String!
+}
+
+type CareSessionPageInfo {
+  hasNextPage: Boolean!
+  endCursor: String
+}
+
+type CareSessionConnection {
+  edges: [CareSessionEdge!]!
+  pageInfo: CareSessionPageInfo!
+}
+
 type BabyStatus {
   lastFeed: FeedActivity
   lastDiaper: DiaperActivity
@@ -199,6 +214,9 @@ type Query {
 
   # Baby Status
   getBabyStatus: BabyStatus!
+
+  # Session History (paginated)
+  getCareSessionHistory(first: Int!, after: String): CareSessionConnection!
 
   # Predictions
   predictNextFeed: NextFeedPrediction!


### PR DESCRIPTION
## Summary

Closes #65

- Add paginated session history query with cursor-based pagination (#65)

## Test plan

- [ ] Verify the changes address the issue requirements
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)